### PR TITLE
Allow Packet EIP inbound to logstash

### DIFF
--- a/terraform/providers/aws/us-east-1/logstash.tf
+++ b/terraform/providers/aws/us-east-1/logstash.tf
@@ -31,7 +31,7 @@ resource "aws_security_group" "logstash" {
     protocol    = "tcp"
     from_port   = "${local.port}"
     to_port     = "${local.port}"
-    cidr_blocks = ["${module.vpc.vpc_cidr_block}"]
+    cidr_blocks = ["${module.vpc.vpc_cidr_block}", "147.75.88.221/32"]
   }
 
   ingress {


### PR DESCRIPTION
This is the (static) Elastic IP from Packet for https://github.com/filecoin-project/rust-proofs-infra/pull/1