### PR TITLE
Update tf to 0.11.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ aliases:
   - &install_terraform
     name: install Terraform
     command: |
-      wget -O /tmp/terraform_0.11.8_linux_amd64.zip https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip
-      unzip -d /go/bin/ /tmp/terraform_0.11.8_linux_amd64.zip
+      wget -O /tmp/terraform_0.11.10_linux_amd64.zip https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip
+      unzip -d /go/bin/ /tmp/terraform_0.11.10_linux_amd64.zip
       chmod +x /go/bin/terraform
   - &init_terraform
     name: init Terraform


### PR DESCRIPTION
Unfortunately all terraform clients that update the state file must be using the same version of terraform. It would appear that @frrist, when making a new cluster was using v 0.11.10 but the nightly builds were using 0.11.8 causing the deploy to fail.

This brings the deploy up to v 0.11.10