### PR TITLE
check for changes on target daemon to avoid race

### DIFF
--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -174,7 +174,7 @@ func TestPaymentChannelRedeemSuccess(t *testing.T) {
 
 		mustRedeemVoucher(t, targetDaemon, voucher, &target)
 
-		ls := listChannelsAsStrs(d, &payer)[0]
+		ls := listChannelsAsStrs(targetDaemon, &payer)[0]
 		assert.Equal(fmt.Sprintf("%v: target: %s, amt: 10000, amt redeemed: 111, eol: 20", channelID.String(), target.String()), ls)
 	})
 }


### PR DESCRIPTION
# Problem
hopefully the last of these. The PaymentBroker daemon tests start up two nodes; one for the payer and the other for the target. The tests usually perform actions then run `actor ls` to confirm the change has taken place. If the action is run on one node, and then the `actor ls` is run on the other, there is small but very non-negligible chance that the results will be queried before the block with the actions has arrived from the other node.

# Solution
Only query on the node where the action was performed.