### PR TITLE
Feat/miner pledge help #1298

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Note: Any flag passed to `go run ./build/*.go test` (e.g. `-cover`) will be pass
 |-------------------------|------------------------------------------------------------------------------------------------|
 | `FIL_API`               | This is the default host and port for daemon commands.                                         |
 | `FIL_PATH`              | Use this variable to avoid setting `--repodir` flag by providing a default value.              |
-| `FIL_USE_SMALL_SECTORS` | Seal alll sector data, as the proofs system only ever seals the first 127 bytes at the moment. |
+| `FIL_USE_SMALL_SECTORS` | Seal all sector data, as the proofs system only ever seals the first 127 bytes at the moment.  |
 | `GO_FILECOIN_LOG_LEVEL` | This sets the log level for stdout.                                                            |
 
 ## Running Filecoin

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -196,6 +196,10 @@ var minerExports = exec.Exports{
 		Params: []abi.Type{abi.PeerID},
 		Return: []abi.Type{},
 	},
+	"getPledge": &exec.FunctionSignature{
+		Params: []abi.Type{},
+		Return: []abi.Type{abi.Integer},
+	},
 	"getPower": &exec.FunctionSignature{
 		Params: []abi.Type{},
 		Return: []abi.Type{abi.Integer},
@@ -462,6 +466,24 @@ func (ma *Actor) UpdatePeerID(ctx exec.VMContext, pid peer.ID) (uint8, error) {
 	}
 
 	return 0, nil
+}
+
+// GetPledge returns the number of pledged sectors
+func (ma *Actor) GetPledge(ctx exec.VMContext) (*big.Int, uint8, error) {
+	var state State
+	ret, err := actor.WithState(ctx, &state, func() (interface{}, error) {
+		return state.PledgeSectors, nil
+	})
+	if err != nil {
+		return nil, errors.CodeError(err), err
+	}
+
+	pledgeSectors, ok := ret.(*big.Int)
+	if !ok {
+		return nil, 1, errors.NewFaultError("Failed to retrieve pledge sectors")
+	}
+
+	return pledgeSectors, 0, nil
 }
 
 // GetPower returns the amount of proven sectors for this miner.

--- a/api/impl/miner.go
+++ b/api/impl/miner.go
@@ -92,6 +92,22 @@ func (api *nodeMiner) GetPower(ctx context.Context, minerAddr address.Address) (
 	return power, nil
 }
 
+func (api *nodeMiner) GetPledge(ctx context.Context, minerAddr address.Address) (*big.Int, error) {
+	bytes, _, err := api.api.Message().Query(
+		ctx,
+		address.Address{},
+		minerAddr,
+		"getPledge",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	power := big.NewInt(0).SetBytes(bytes[0])
+
+	return power, nil
+}
+
 func (api *nodeMiner) GetTotalPower(ctx context.Context) (*big.Int, error) {
 	bytes, _, err := api.api.Message().Query(
 		ctx,

--- a/api/miner.go
+++ b/api/miner.go
@@ -17,6 +17,7 @@ type Miner interface {
 	UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, newPid peer.ID) (*cid.Cid, error)
 	AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, price *types.AttoFIL, expiry *big.Int) (*cid.Cid, error)
 	GetOwner(ctx context.Context, minerAddr address.Address) (address.Address, error)
+	GetPledge(ctx context.Context, minerAddr address.Address) (*big.Int, error)
 	GetPower(ctx context.Context, minerAddr address.Address) (*big.Int, error)
 	GetTotalPower(ctx context.Context) (*big.Int, error)
 }


### PR DESCRIPTION
# Problem
This is to address #1298 More detail about mining pledge

# Solution
Add a "miner pledge" command that takes a miner address.
Add a little more description to the miner create command help
Add some tests

**Here is the new miner help showing the pledge command:**
```
USAGE
  go-filecoin miner - Manage miner operations

SYNOPSIS
  go-filecoin miner

SUBCOMMANDS
  go-filecoin miner add-ask <miner> <price> <expiry> - Add an ask to the storage market
  go-filecoin miner create <pledge> <collateral>     - Create a new file miner with <pledge> 1GB sectors and <collateral> FIL
  go-filecoin miner owner <miner>                    - Show the actor address of <miner>
  go-filecoin miner pledge <miner>                   - View number of pledged, 1GB sectors for <miner>
  go-filecoin miner power <miner>                    - Get the power of a miner versus the total storage market power
  go-filecoin miner update-peerid <address> <peerid> - Change the libp2p identity that a miner is operating
```

Here is the miner pledge help:
```
USAGE
  go-filecoin miner pledge <miner> - View number of pledged, 1GB sectors for <miner>

SYNOPSIS
  go-filecoin miner pledge [--] <miner>

ARGUMENTS

  <miner> - the miner address

DESCRIPTION

  Shows the number of pledged 1GB sectors for the given miner address
```