### PR TITLE
Made gengen seed configurable via a flag

### DIFF
--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -255,7 +255,7 @@ func TestMinerOwner(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = gengen.GenGenesisCar(testConfig, fi); err != nil {
+	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -293,7 +293,7 @@ func TestMinerPower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = gengen.GenGenesisCar(testConfig, fi); err != nil {
+	if _, err = gengen.GenGenesisCar(testConfig, fi, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	gengen "github.com/filecoin-project/go-filecoin/gengen/util"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -56,11 +57,14 @@ set the initial genesis block:
 $ go-filecoin init --genesisfile=genesis.car
 */
 func main() {
+	var defaultSeed = time.Now().Unix()
+
 	jsonout := flag.Bool("json", false, "sets output to be json")
 	keypath := flag.String("keypath", ".", "sets location to write key files to")
 	outJSON := flag.String("out-json", "", "enables json output and writes it to the given file")
 	outCar := flag.String("out-car", "", "writes the generated car file to the give path, instead of stdout")
 	configFilePath := flag.String("config", "", "reads configuration from this json file, instead of stdin")
+	seed := flag.Int64("seed", defaultSeed, "provides the seed for randomization, defaults to current unix epoch")
 
 	flag.Parse()
 
@@ -79,7 +83,7 @@ func main() {
 		}
 		outfile = f
 	}
-	info, err := gengen.GenGenesisCar(cfg, outfile)
+	info, err := gengen.GenGenesisCar(cfg, outfile, *seed)
 	if err != nil {
 		panic(err)
 	}

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	mrand "math/rand"
 	"strconv"
-	"time"
 
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
@@ -29,9 +28,6 @@ import (
 	blockstore "gx/ipfs/QmcmpX42gtDv1fz24kau4wjS9hfwWj5VexWBKgGnWzsyag/go-ipfs-blockstore"
 	dag "gx/ipfs/QmeLG6jF1xvEmHca5Vy4q4EdQWp8Xq9S6EPyZrN9wvSRLC/go-merkledag"
 )
-
-// seed is used to make all randomness (keys and fake commitments) deterministic.
-var seed = time.Now().Unix()
 
 // Miner is
 type Miner struct {
@@ -91,7 +87,7 @@ type RenderedMinerInfo struct {
 // the final genesis block.
 //
 // WARNING: Do not use maps in this code, they will make this code non deterministic.
-func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs blockstore.Blockstore) (*RenderedGenInfo, error) {
+func GenGen(ctx context.Context, cfg *GenesisCfg, cst *hamt.CborIpldStore, bs blockstore.Blockstore, seed int64) (*RenderedGenInfo, error) {
 	pnrg := mrand.New(mrand.NewSource(seed))
 	keys, err := genKeys(cfg.Keys, pnrg)
 	if err != nil {
@@ -292,7 +288,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 }
 
 // GenGenesisCar generates a car for the given genesis configuration
-func GenGenesisCar(cfg *GenesisCfg, out io.Writer) (*RenderedGenInfo, error) {
+func GenGenesisCar(cfg *GenesisCfg, out io.Writer, seed int64) (*RenderedGenInfo, error) {
 	// TODO: these six lines are ugly. We can do better...
 	mds := ds.NewMapDatastore()
 	bstore := blockstore.NewBlockstore(mds)
@@ -303,7 +299,7 @@ func GenGenesisCar(cfg *GenesisCfg, out io.Writer) (*RenderedGenInfo, error) {
 
 	ctx := context.Background()
 
-	info, err := GenGen(ctx, cfg, cst, bstore)
+	info, err := GenGen(ctx, cfg, cst, bstore, seed)
 	if err != nil {
 		return nil, err
 	}

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -37,7 +37,7 @@ func TestGenGenLoading(t *testing.T) {
 	fi, err := ioutil.TempFile("", "gengentest")
 	assert.NoError(err)
 
-	_, err = GenGenesisCar(testConfig, fi)
+	_, err = GenGenesisCar(testConfig, fi, 0)
 	assert.NoError(err)
 	assert.NoError(fi.Close())
 
@@ -64,7 +64,7 @@ func TestGenGenDeterministicBetweenBuilds(t *testing.T) {
 
 		ctx := context.Background()
 
-		inf, err := GenGen(ctx, testConfig, cst, bstore)
+		inf, err := GenGen(ctx, testConfig, cst, bstore, 0)
 		assert.NoError(err)
 		if info == nil {
 			info = inf

--- a/node/testing.go
+++ b/node/testing.go
@@ -56,7 +56,7 @@ func MakeChainSeed(t *testing.T, cfg *gengen.GenesisCfg) *ChainSeed {
 	blkserv := bserv.New(bstore, offl)
 	cst := &hamt.CborIpldStore{Blocks: blkserv}
 
-	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore)
+	info, err := gengen.GenGen(context.TODO(), cfg, cst, bstore, 0)
 	require.NoError(t, err)
 
 	return &ChainSeed{


### PR DESCRIPTION
# Problem

GenGen is currently non-deterministic and so are the tests

# Solution

Make the randomization seed that GenGen uses configurable, so we can make deterministic genesis files when we want them and non-deterministic ones when we don't.