### PR TITLE
put price argument in correct place

### DIFF
--- a/tools/iptb-plugins/filecoin/local/scripts/prepMining.sh
+++ b/tools/iptb-plugins/filecoin/local/scripts/prepMining.sh
@@ -91,7 +91,7 @@ do
 
     echo $newMinerAddr
     echo $dataCid
-    iptb run 0 -- go-filecoin client propose-storage-deal --price 1 "$newMinerAddr" "$dataCid" 10000  # I think this is where stuff fails right now??
+    iptb run 0 -- go-filecoin client propose-storage-deal "$newMinerAddr" "$dataCid" 1 10000  # I think this is where stuff fails right now??
 done
 
 printf "Complete! %d nodes connected and ready to mine >.>" "$1"


### PR DESCRIPTION
# Problem
Script outputs errors like:
```
node[0] exit 1

unknown option "price"
```

# Solution
Add price as an inline argument in propose-storage-deal.