### PR TITLE
[WIP] Remove dependency between network libp2p network tests

### DIFF
--- a/protocol/hello/hello_test.go
+++ b/protocol/hello/hello_test.go
@@ -35,6 +35,8 @@ func (mhg *mockHeaviestGetter) getHeaviestTipSet() consensus.TipSet {
 }
 
 func TestHelloHandshake(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -60,8 +62,10 @@ func TestHelloHandshake(t *testing.T) {
 	msc1.On("SyncCallback", b.ID(), heavy2.ToSortedCidSet().ToSlice(), uint64(3)).Return()
 	msc2.On("SyncCallback", a.ID(), heavy1.ToSortedCidSet().ToSlice(), uint64(2)).Return()
 
-	require.NoError(mn.LinkAll())
-	require.NoError(mn.ConnectAllButSelf())
+	_, err = mn.LinkPeers(a.ID(), b.ID())
+	require.NoError(err)
+	_, err = mn.ConnectPeers(a.ID(), b.ID())
+	require.NoError(err)
 
 	require.NoError(th.WaitForIt(10, 50*time.Millisecond, func() (bool, error) {
 		var msc1Done bool
@@ -88,6 +92,8 @@ func TestHelloHandshake(t *testing.T) {
 }
 
 func TestHelloBadGenesis(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require := require.New(t)
@@ -113,8 +119,10 @@ func TestHelloBadGenesis(t *testing.T) {
 	msc1.On("SyncCallback", mock.Anything, mock.Anything, mock.Anything).Return()
 	msc2.On("SyncCallback", mock.Anything, mock.Anything, mock.Anything).Return()
 
-	require.NoError(mn.LinkAll())
-	require.NoError(mn.ConnectAllButSelf())
+	_, err = mn.LinkPeers(a.ID(), b.ID())
+	require.NoError(err)
+	_, err = mn.ConnectPeers(a.ID(), b.ID())
+	require.NoError(err)
 
 	time.Sleep(time.Millisecond * 50)
 
@@ -123,6 +131,8 @@ func TestHelloBadGenesis(t *testing.T) {
 }
 
 func TestHelloMultiBlock(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require := require.New(t)
@@ -155,8 +165,10 @@ func TestHelloMultiBlock(t *testing.T) {
 	msc1.On("SyncCallback", b.ID(), heavy2.ToSortedCidSet().ToSlice(), uint64(3)).Return()
 	msc2.On("SyncCallback", a.ID(), heavy1.ToSortedCidSet().ToSlice(), uint64(2)).Return()
 
-	mn.LinkAll()
-	mn.ConnectAllButSelf()
+	_, err = mn.LinkPeers(a.ID(), b.ID())
+	require.NoError(err)
+	_, err = mn.ConnectPeers(a.ID(), b.ID())
+	require.NoError(err)
 
 	time.Sleep(time.Millisecond * 50)
 


### PR DESCRIPTION
# Problem 
We experienced a test failure in hello protocol in CI. The failure looks like:
```
14:28:57.232 ERROR /fil/hello: Their genesis cid: zDPWYqFD7LSWrpMKu59H3gZcmbQtkHN787pDhTuXdbb55apgbPSn hello.go:97
14:28:57.233 ERROR /fil/hello: Our genesis cid: zDPWYqFCwL1EuAu791SyDa1L7UyvMeg6wjNKDNAQnaT7wUM8rY64 hello.go:98
14:28:57.233 ERROR /fil/hello: bad genesis, disconnecting from peer hello.go:82
panic: 

mock: Unexpected Method Call
-----------------------------

SyncCallback(peer.ID,[]*cid.Cid,uint64)
		0: "\x00\x05#\x11o\x8bY"
		1: []*cid.Cid{(*cid.Cid)(0xc42031ae10), (*cid.Cid)(0xc42031ae70), (*cid.Cid)(0xc42031aed0)}
		2: 0x3

The closest call I have is: 

SyncCallback(peer.ID,[]*cid.Cid,uint64)
		0: "\x00\x05#\x11o\x8bY"
		1: []*cid.Cid{(*cid.Cid)(0xc42022dbc0), (*cid.Cid)(0xc420250600), (*cid.Cid)(0xc420250ed0)}
		2: 0x2
```

The errors is thrown from `hello_test.go:58 +0x66` in the `TestHelloHandshake` function. We've determined that the bad genesis CID is created in the following test, `TestHelloBadGenesis`. The hypothesis is test parallelization is allowing hosts from one test to talk to host generated in the other test through libp2p.

# Solution
Stop running these tests in parallel because the aren't independent.

Actually, there are some complications. Still need to think through this one.