### PR TITLE
Fix bug for start/stop/start not restarting the mining scheduler

### DIFF
--- a/mining/testing.go
+++ b/mining/testing.go
@@ -21,12 +21,20 @@ const MineDelayTest = time.Millisecond * 500
 // MockScheduler is a mock Scheduler.
 type MockScheduler struct {
 	mock.Mock
+	isStarted bool
 }
 
 // Start is the MockScheduler's Start function.
 func (s *MockScheduler) Start(ctx context.Context) (<-chan Output, *sync.WaitGroup) {
 	args := s.Called(ctx)
+	s.isStarted = true
 	return args.Get(0).(<-chan Output), args.Get(1).(*sync.WaitGroup)
+}
+
+// IsStarted is the equivalent to scheduler.IsStarted, to know when the scheduler
+// has been started.
+func (s *MockScheduler) IsStarted() bool {
+	return s.isStarted
 }
 
 // TestWorker is a worker with a customizable work function to facilitate


### PR DESCRIPTION
## Problem
Issue #1396 `mining start` + `mining stop` + `mining start` doesn't start mining
After a mining stop command, the scheduler isn't nil, however, the node never starts the scheduler unless there wasn't one to begin with.  So the scheduler never gets restarted.
Also, two mining start commands don't tell you if you are already mining, and it goes through a bunch of work unnecessarily.

with @rosalinekarr @acruikshank 

## Solution
Add `isStarted` field + `IsStarted` accessor to `Scheduler`, which when started is set to true, and when the `node.miningContext` is Done it is set to false.
* Changes to StartMining:
    - If we are already mining, return with an error message.
    - Otherwise, do the mining set up as usual, but check if the scheduler has been started.  If not, set up and start the mining context, mining scheduler, channel & wait group. Maybe not necessary since we bail at the beginning if mining itself is already started, but just in case.

## Risks
So far mining is only started via CLI, so there are no internal calls that will receive a "surprising" error message on a double start.  If there are scripts that run the CLI command to start and mistakenly call a double start, they will have to handle an error message.
