### PR TITLE
Wait for daemon to exit in retrieval test

### DIFF
--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -3,14 +3,23 @@
 set -eo pipefail
 
 function finish {
+  local -i MAX_WAIT=60
+
   echo ""
   echo "cleaning up..."
   kill "$MN_PID" || true
   kill "$CL_PID" || true
 
-  # Force KILL after 10 seconds if the daemons don't exit
-  (sleep 10 && kill -9 "$MN_PID") & WAITER_MN=$!
-  (sleep 10 && kill -9 "$CL_PID") & WAITER_CL=$!
+  # Force KILL after MAX_WAIT seconds if the daemons don't exit
+  (
+    sleep $MAX_WAIT && kill -9 "$MN_PID";
+    echo "Sent SIGKILL to MN, daemon failed to stop within $MAX_WAIT second at end of test";
+  ) & WAITER_MN=$!
+
+  (
+    sleep $MAX_WAIT && kill -9 "$CL_PID";
+    echo "Sent SIGKILL to CL, daemon failed to stop within $MAX_WAIT second at end of test";
+  ) & WAITER_CL=$!
 
   # Wait for daemons to exit
   wait "$MN_PID"


### PR DESCRIPTION
Not waiting around for the daemon to exit before blowing away the repo
does not allow the daemon to exit cleanly and gives us a false negative.

Fixes #1442


(Sorry this commit message sounds super blunt :rofl:)