### PR TITLE
use xlarge box, tag images with GIT SHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,19 +228,28 @@ jobs:
       - run:
           name: build & push image - filecoin
           command: |
-            docker build -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest .
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker build -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA .
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
             docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:latest
 
       - run:
           name: build & push image - genesis file server
           command: |
-            docker build -f Dockerfile.genesis -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest .
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker build -f Dockerfile.genesis -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA .
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
             docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:latest
 
       - run:
           name: build & push image - faucet
           command: |
-            docker build -f Dockerfile.faucet -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest .
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker build -f Dockerfile.faucet -t 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA .
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
             docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:latest
 
 workflows:


### PR DESCRIPTION
- use xlarge resource to speed up docker build
- tag docker images with GIT SHA in addition to latest