### PR TITLE
stop pruning the msgpool in block generation

### DIFF
--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -102,7 +102,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	}
 
 	// Mining reward message succeeded -- side effects okay below this point.
-	
+
 	// TODO: Should we really be pruning the message pool here at all? Maybe this should happen elsewhere.
 	for i, msg := range res.PermanentFailures {
 		// We will not be able to apply this message in the future because the error was permanent.

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -261,8 +261,9 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 	blk, err := worker.Generate(ctx, consensus.RequireNewTipSet(require, &baseBlock), nil, 0)
 	assert.NoError(err)
 
-	assert.Len(pool.Pending(), 2) // This is the temporary failure + the good message,
-                                  // which will be removed by the node if this block is accepted.
+	// This is the temporary failure + the good message,
+	// which will be removed by the node if this block is accepted.
+	assert.Len(pool.Pending(), 2)
 	assert.Contains(pool.Pending(), smsg1)
 	assert.Contains(pool.Pending(), smsg2)
 


### PR DESCRIPTION
This fixes one of the bugs in https://github.com/filecoin-project/go-filecoin/issues/1457#issuecomment-445074315. Progress towards #1457 .