### PR TITLE
Feat/human readable output from go-filecoin show block 1060

### DIFF
--- a/commands/block.go
+++ b/commands/block.go
@@ -24,9 +24,9 @@ var showCmd = &cmds.Command{
 var showBlockCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show a filecoin block by its CID",
-		ShortDescription: `Prints the miner, ticket, parent weight numerator, parent weight denominator,
-height and nonce of a given block. If JSON encoding is specified with the --enc
-flag, all other block properties will be included as well.`,
+		ShortDescription: `Prints the miner, parent weight numerator, parent weight denominator, height,
+and nonce of a given block. If JSON encoding is specified with the --enc flag,
+all other block properties will be included as well.`,
 	},
 	Arguments: []cmdkit.Argument{
 		cmdkit.StringArg("ref", true, false, "CID of block to show"),
@@ -49,14 +49,12 @@ flag, all other block properties will be included as well.`,
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, block *types.Block) error {
 			_, err := fmt.Fprintf(w, `Block Details
 Miner:       %s
-Ticket:      %s
 Numerator:   %s
 Denominator: %s
 Height:      %s
 Nonce:       %s
 `,
 				block.Miner,
-				block.Ticket,
 				strconv.FormatUint(uint64(block.ParentWeightNum), 10),
 				strconv.FormatUint(uint64(block.ParentWeightDenom), 10),
 				strconv.FormatUint(uint64(block.Height), 10),

--- a/commands/block_daemon_test.go
+++ b/commands/block_daemon_test.go
@@ -8,12 +8,32 @@ import (
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBlockDaemon(t *testing.T) {
 	t.Parallel()
-	t.Run("show block <cid-of-genesis-block> --enc json returns JSON for a Filecoin block", func(t *testing.T) {
+	t.Run("show block <cid-of-genesis-block> returns human readable output for the filecoin block", func(t *testing.T) {
+		assert := assert.New(t)
+
+		d := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0])).Start()
+		defer d.ShutdownSuccess()
+
+		// mine a block and get its CID
+		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
+
+		// get the mined block by its CID
+		output := d.RunSuccess("show", "block", minedBlockCidStr).ReadStdoutTrimNewlines()
+
+		assert.Contains(output, "Block Details")
+		assert.Contains(output, "Numerator:   0")
+		assert.Contains(output, "Denominator: 1")
+		assert.Contains(output, "Height:      1")
+		assert.Contains(output, "Nonce:       0")
+	})
+
+	t.Run("show block <cid-of-genesis-block> --enc json returns JSON for a filecoin block", func(t *testing.T) {
 		require := require.New(t)
 
 		d := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0])).Start()
@@ -23,7 +43,6 @@ func TestBlockDaemon(t *testing.T) {
 		minedBlockCidStr := th.RunSuccessFirstLine(d, "mining", "once")
 
 		// get the mined block by its CID
-
 		blockGetLine := th.RunSuccessFirstLine(d, "show", "block", minedBlockCidStr, "--enc", "json")
 		var blockGetBlock types.Block
 		json.Unmarshal([]byte(blockGetLine), &blockGetBlock)


### PR DESCRIPTION
# Problem

The output of `go-filecoin show block` [does not format numbers in a human readable manner](
https://github.com/filecoin-project/go-filecoin/issues/1070). It also doesn't format anything in a human manner.

# Solution

Make `go-filecoin show block` print formatted, human-readable text instead of LEB128 encoded JSON