### PR TITLE
REDO: Refactor for great <del>justice</del> node testing

### DIFF
--- a/api/impl/actor_test.go
+++ b/api/impl/actor_test.go
@@ -35,7 +35,7 @@ func TestActorLs(t *testing.T) {
 		require := require.New(t)
 		ctx := context.Background()
 
-		nd := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		nd := node.MakeOfflineNode(t)
 
 		_, err := ls(ctx, nd, getActorsNoOp)
 		require.Error(err)
@@ -51,7 +51,7 @@ func TestActorLs(t *testing.T) {
 		require := require.New(t)
 		ctx := context.Background()
 
-		nd := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		nd := node.MakeOfflineNode(t)
 
 		genBlock, err := consensus.InitGenesis(nd.CborStore(), nd.Blockstore)
 		require.NoError(err)

--- a/api/impl/chain_test.go
+++ b/api/impl/chain_test.go
@@ -20,7 +20,7 @@ func TestChainHead(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		_, err := api.Chain().Head()
@@ -36,7 +36,7 @@ func TestChainHead(t *testing.T) {
 		assert := assert.New(t)
 
 		blk := types.NewBlockForTest(nil, 1)
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		chainStore, ok := n.ChainReader.(chain.Store)
 		require.True(ok)
 
@@ -60,7 +60,7 @@ func TestChainHead(t *testing.T) {
 		blk2 := types.NewBlockForTest(nil, 1)
 		blk3 := types.NewBlockForTest(nil, 2)
 
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		chainStore, ok := n.ChainReader.(chain.Store)
 		require.True(ok)
 
@@ -90,7 +90,7 @@ func TestChainLsRun(t *testing.T) {
 		assert := assert.New(t)
 
 		ctx := context.Background()
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 
 		chainStore, ok := n.ChainReader.(chain.Store)
 		require.True(ok)
@@ -129,7 +129,7 @@ func TestChainLsRun(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 
 		parBlock := types.NewBlockForTest(nil, 0)
 		chlBlock := types.NewBlockForTest(parBlock, 1)

--- a/api/impl/config_test.go
+++ b/api/impl/config_test.go
@@ -17,7 +17,7 @@ func TestConfigGet(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
 
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 
 		api := New(n)
 
@@ -31,7 +31,7 @@ func TestConfigGet(t *testing.T) {
 	t.Run("failure cases fail", func(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		_, err := api.Config().Get("nonexistantkey")
@@ -45,6 +45,15 @@ func TestConfigGet(t *testing.T) {
 	})
 }
 
+func nodeConfigFunc() node.ConfigOpt {
+	defaultCfg := config.NewDefaultConfig()
+	return func(c *node.Config) error {
+		c.Repo.Config().Mining.AutoSealIntervalSeconds = defaultCfg.Mining.AutoSealIntervalSeconds
+		c.Repo.Config().API.Address = defaultCfg.API.Address // overwrite value set with testhelpers.GetFreePort()
+		return nil
+	}
+}
+
 func TestConfigSet(t *testing.T) {
 	t.Parallel()
 	t.Run("sets the config value", func(t *testing.T) {
@@ -54,11 +63,7 @@ func TestConfigSet(t *testing.T) {
 
 		defaultCfg := config.NewDefaultConfig()
 
-		n := node.MakeNodesUnstarted(t, 1, true, true, func(c *node.Config) error {
-			c.Repo.Config().Mining.AutoSealIntervalSeconds = defaultCfg.Mining.AutoSealIntervalSeconds
-			c.Repo.Config().API.Address = defaultCfg.API.Address // overwrite value set with testhelpers.GetFreePort()
-			return nil
-		})[0]
+		n := node.MakeNodesUnstarted(t, 1, true, true, []node.ConfigOpt{nodeConfigFunc()})[0]
 		api := New(n)
 		jsonBlob := `{"addresses": ["bootup1", "bootup2"]}`
 
@@ -87,7 +92,7 @@ func TestConfigSet(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		// bad key
@@ -117,7 +122,7 @@ func TestConfigSet(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		err := api.Config().Set("heartbeat.nickname", "Bad Nickname")

--- a/api/impl/dag_test.go
+++ b/api/impl/dag_test.go
@@ -21,7 +21,7 @@ func TestDagGet(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 		ctx := context.Background()
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		_, err := api.Dag().Get(ctx, "awful")
@@ -33,7 +33,7 @@ func TestDagGet(t *testing.T) {
 		assert := assert.New(t)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
 		defer cancel()
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		someCid := types.SomeCid()
@@ -46,7 +46,7 @@ func TestDagGet(t *testing.T) {
 		t.Parallel()
 		assert := assert.New(t)
 		ctx := context.Background()
-		n := node.MakeNodesUnstarted(t, 1, true, true)[0]
+		n := node.MakeOfflineNode(t)
 		api := New(n)
 
 		ipldnode := types.NewBlockForTest(nil, 1234).ToNode()

--- a/api/impl/helpers_test.go
+++ b/api/impl/helpers_test.go
@@ -13,7 +13,7 @@ func TestSetDefaultFromAddr(t *testing.T) {
 	assert := assert.New(t)
 
 	addr := address.Address{}
-	nd := node.MakeNodesUnstarted(t, 1, true, true)[0]
+	nd := node.MakeOfflineNode(t)
 
 	expected, err := message.GetAndMaybeSetDefaultSenderAddress(nd.Repo, nd.Wallet)
 	assert.NoError(err)

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -45,7 +45,7 @@ func TestBlockPropTwoNodes(t *testing.T) {
 	defer cancel()
 	assert := assert.New(t)
 
-	nodes := MakeNodesUnstarted(t, 2, false, true)
+	nodes := MakeNodesUnstarted(t, 2, false, true, nil)
 	startNodes(t, nodes)
 	defer stopNodes(nodes)
 	connect(t, nodes[0], nodes[1])
@@ -84,7 +84,7 @@ func TestChainSync(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 
-	nodes := MakeNodesUnstarted(t, 2, false, true)
+	nodes := MakeNodesUnstarted(t, 2, false, true, nil)
 	startNodes(t, nodes)
 	defer stopNodes(nodes)
 

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -18,7 +18,7 @@ func TestMessagePropagation(t *testing.T) {
 	defer cancel()
 	require := require.New(t)
 
-	nodes := MakeNodesUnstarted(t, 3, false, true)
+	nodes := MakeNodesUnstarted(t, 3, false, true, nil)
 	startNodes(t, nodes)
 	defer stopNodes(nodes)
 	connect(t, nodes[0], nodes[1])

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -30,7 +30,7 @@ func TestNodeConstruct(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	nd := MakeNodesUnstarted(t, 1, false, true)[0]
+	nd := MakeNodesUnstarted(t, 1, false, true, nil)[0]
 	assert.NotNil(nd.Host)
 
 	nd.Stop(context.Background())
@@ -41,7 +41,7 @@ func TestNodeNetworking(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 
-	nds := MakeNodesUnstarted(t, 2, false, true)
+	nds := MakeNodesUnstarted(t, 2, false, true, nil)
 	nd1, nd2 := nds[0], nds[1]
 
 	pinfo := peerstore.PeerInfo{
@@ -129,7 +129,7 @@ func TestNodeInit(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	nd := MakeNodesUnstarted(t, 1, true, true)[0]
+	nd := MakeOfflineNode(t)
 
 	assert.NoError(nd.Start(ctx))
 
@@ -267,7 +267,7 @@ func TestUpdateMessagePool(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := context.Background()
-	node := MakeNodesUnstarted(t, 1, true, false)[0]
+	node := MakeNodesUnstarted(t, 1, true, false, nil)[0]
 	chainForTest, ok := node.ChainReader.(chain.Store)
 	require.True(ok)
 
@@ -316,7 +316,7 @@ func TestGetSignature(t *testing.T) {
 		ctx := context.Background()
 		assert := assert.New(t)
 
-		nd := MakeNodesUnstarted(t, 1, true, true)[0]
+		nd := MakeOfflineNode(t)
 		nodeAddr, err := nd.NewAddress()
 		assert.NoError(err)
 
@@ -386,7 +386,7 @@ func TestSendMessage(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
 
-		node := MakeNodesUnstarted(t, 1, true, true)[0]
+		node := MakeOfflineNode(t)
 		nodeAddr, err := node.NewAddress()
 		assert.NoError(err)
 
@@ -413,7 +413,7 @@ func TestQueryMessage(t *testing.T) {
 		require := require.New(t)
 		ctx := context.Background()
 
-		node := MakeNodesUnstarted(t, 1, true, true)[0]
+		node := MakeOfflineNode(t)
 		nodeAddr, err := node.NewAddress()
 		require.NoError(err)
 


### PR DESCRIPTION
Had to redo this PR (see #1500) and branch due to a failed rebase; it's exactly the same as before.

* Small refactor to allow for easier and more consistent node config in testing.
* Always use MakeOfflineNode(t) convenience function instead of
  MakeNodesUnstarted(t, 1, true, true)[0]
* Change signature/params of some node test helpers slightly
* This is to ultimately enhance configurability of nodes in tests, to improve ease of use and readabiity.

Related to #1490 and #1454 