### PR TITLE
Use miner address instead of peer id

### DIFF
--- a/api/impl/retrieval_client.go
+++ b/api/impl/retrieval_client.go
@@ -5,7 +5,8 @@ import (
 	"io"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/QmcqU6QUDSXprb1518vYDGczrTJTyGwLG9eUa5iNX4xUtS/go-libp2p-peer"
+
+	"github.com/filecoin-project/go-filecoin/address"
 )
 
 type nodeRetrievalClient struct {
@@ -16,6 +17,11 @@ func newNodeRetrievalClient(api *nodeAPI) *nodeRetrievalClient {
 	return &nodeRetrievalClient{api: api}
 }
 
-func (nrc *nodeRetrievalClient) RetrievePiece(ctx context.Context, minerPeerID peer.ID, pieceCID cid.Cid) (io.ReadCloser, error) {
+func (nrc *nodeRetrievalClient) RetrievePiece(ctx context.Context, pieceCID cid.Cid, minerAddr address.Address) (io.ReadCloser, error) {
+	minerPeerID, err := nrc.api.node.Lookup().GetPeerIDByMinerAddress(ctx, minerAddr)
+	if err != nil {
+		return nil, err
+	}
+
 	return nrc.api.node.RetrievalClient.RetrievePiece(ctx, minerPeerID, pieceCID)
 }

--- a/api/retrieval_client.go
+++ b/api/retrieval_client.go
@@ -5,10 +5,11 @@ import (
 	"io"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	"gx/ipfs/QmcqU6QUDSXprb1518vYDGczrTJTyGwLG9eUa5iNX4xUtS/go-libp2p-peer"
+
+	"github.com/filecoin-project/go-filecoin/address"
 )
 
 // RetrievalClient is the interface that defines methods to manage retrieval client operations.
 type RetrievalClient interface {
-	RetrievePiece(ctx context.Context, minerPeerID peer.ID, pieceCID cid.Cid) (io.ReadCloser, error)
+	RetrievePiece(ctx context.Context, pieceCID cid.Cid, minerAddr address.Address) (io.ReadCloser, error)
 }

--- a/commands/retrieval_client.go
+++ b/commands/retrieval_client.go
@@ -3,8 +3,9 @@ package commands
 import (
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/Qma6uuSyjkecGhMFFLfzyJDPyoDtNJSHJNweDccZhaWkgU/go-ipfs-cmds"
-	"gx/ipfs/QmcqU6QUDSXprb1518vYDGczrTJTyGwLG9eUa5iNX4xUtS/go-libp2p-peer"
 	"gx/ipfs/Qmde5VP1qUkyQXKCfmEUA7bP64V2HAptbJ7phuPp7jXWwg/go-ipfs-cmdkit"
+
+	"github.com/filecoin-project/go-filecoin/address"
 )
 
 var retrievalClientCmd = &cmds.Command{
@@ -21,11 +22,11 @@ var clientRetrievePieceCmd = &cmds.Command{
 		Tagline: "Read out piece data stored by a miner on the network",
 	},
 	Arguments: []cmdkit.Argument{
-		cmdkit.StringArg("pid", true, false, "libp2p peer id of storage miner"),
+		cmdkit.StringArg("miner", true, false, "Retrieval miner actor address"),
 		cmdkit.StringArg("cid", true, false, "Content identifier of piece to read"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		minerPeerID, err := peer.IDB58Decode(req.Arguments[0])
+		minerAddr, err := address.NewFromString(req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -35,7 +36,7 @@ var clientRetrievePieceCmd = &cmds.Command{
 			return err
 		}
 
-		readCloser, err := GetAPI(env).RetrievalClient().RetrievePiece(req.Context, minerPeerID, pieceCID)
+		readCloser, err := GetAPI(env).RetrievalClient().RetrievePiece(req.Context, pieceCID, minerAddr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Switch `retrieval-client retrieve-piece` to use a miner ID and CID in the same order as `client propose-storage-deal`

Issue: https://github.com/filecoin-project/go-filecoin/issues/1162