### PR TITLE
Add gas price and limit to signed message

### DIFF
--- a/api/impl/miner.go
+++ b/api/impl/miner.go
@@ -22,7 +22,7 @@ func newNodeMiner(api *nodeAPI, plumbingAPI api2.Plumbing) *nodeMiner {
 	return &nodeMiner{api: api, plumbingAPI: plumbingAPI}
 }
 
-func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error) {
+func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error) {
 	nd := nm.api.node
 
 	if err := setDefaultFromAddr(&fromAddr, nd); err != nil {
@@ -33,7 +33,7 @@ func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, pledg
 		pid = nd.Host().ID()
 	}
 
-	res, err := nd.CreateMiner(ctx, fromAddr, pledge, pid, collateral)
+	res, err := nd.CreateMiner(ctx, fromAddr, gasPrice, gasLimit, pledge, pid, collateral)
 	if err != nil {
 		return address.Address{}, errors.Wrap(err, "Could not create miner. Please consult the documentation to setup your wallet and genesis block correctly")
 	}
@@ -41,23 +41,27 @@ func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, pledg
 	return *res, nil
 }
 
-func (nm *nodeMiner) UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, newPid peer.ID) (cid.Cid, error) {
+func (nm *nodeMiner) UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, newPid peer.ID) (cid.Cid, error) {
 	return nm.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
 		minerAddr,
 		nil,
+		gasPrice,
+		gasLimit,
 		"updatePeerID",
 		newPid,
 	)
 }
 
-func (nm *nodeMiner) AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error) {
+func (nm *nodeMiner) AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error) {
 	return nm.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
 		minerAddr,
 		nil,
+		gasPrice,
+		gasLimit,
 		"addAsk",
 		price,
 		expiry,

--- a/api/impl/paych.go
+++ b/api/impl/paych.go
@@ -21,12 +21,14 @@ func newNodePaych(api *nodeAPI, plumbingAPI api2.Plumbing) *nodePaych {
 	return &nodePaych{api: api, plumbingAPI: plumbingAPI}
 }
 
-func (np *nodePaych) Create(ctx context.Context, fromAddr, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
+func (np *nodePaych) Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
 	return np.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
 		address.PaymentBrokerAddress,
 		amount,
+		gasPrice,
+		gasLimit,
 		"createChannel",
 		target, eol,
 	)
@@ -100,7 +102,7 @@ func (np *nodePaych) Voucher(ctx context.Context, fromAddr address.Address, chan
 	return multibase.Encode(multibase.Base58BTC, cborVoucher)
 }
 
-func (np *nodePaych) Redeem(ctx context.Context, fromAddr address.Address, voucherRaw string) (cid.Cid, error) {
+func (np *nodePaych) Redeem(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error) {
 	voucher, err := decodeVoucher(voucherRaw)
 	if err != nil {
 		return cid.Undef, err
@@ -111,23 +113,27 @@ func (np *nodePaych) Redeem(ctx context.Context, fromAddr address.Address, vouch
 		fromAddr,
 		address.PaymentBrokerAddress,
 		types.NewAttoFILFromFIL(0),
+		gasPrice,
+		gasLimit,
 		"redeem",
 		voucher.Payer, &voucher.Channel, &voucher.Amount, []byte(voucher.Signature),
 	)
 }
 
-func (np *nodePaych) Reclaim(ctx context.Context, fromAddr address.Address, channel *types.ChannelID) (cid.Cid, error) {
+func (np *nodePaych) Reclaim(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID) (cid.Cid, error) {
 	return np.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
 		address.PaymentBrokerAddress,
 		types.NewAttoFILFromFIL(0),
+		gasPrice,
+		gasLimit,
 		"reclaim",
 		channel,
 	)
 }
 
-func (np *nodePaych) Close(ctx context.Context, fromAddr address.Address, voucherRaw string) (cid.Cid, error) {
+func (np *nodePaych) Close(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error) {
 	voucher, err := decodeVoucher(voucherRaw)
 	if err != nil {
 		return cid.Undef, err
@@ -138,17 +144,21 @@ func (np *nodePaych) Close(ctx context.Context, fromAddr address.Address, vouche
 		fromAddr,
 		address.PaymentBrokerAddress,
 		types.NewAttoFILFromFIL(0),
+		gasPrice,
+		gasLimit,
 		"close",
 		voucher.Payer, &voucher.Channel, &voucher.Amount, []byte(voucher.Signature),
 	)
 }
 
-func (np *nodePaych) Extend(ctx context.Context, fromAddr address.Address, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
+func (np *nodePaych) Extend(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
 	return np.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
 		address.PaymentBrokerAddress,
 		amount,
+		gasPrice,
+		gasLimit,
 		"extend",
 		channel, eol,
 	)

--- a/api/miner.go
+++ b/api/miner.go
@@ -13,9 +13,9 @@ import (
 
 // Miner is the interface that defines methods to manage miner operations.
 type Miner interface {
-	Create(ctx context.Context, fromAddr address.Address, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error)
-	UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, newPid peer.ID) (cid.Cid, error)
-	AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error)
+	Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error)
+	UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, newPid peer.ID) (cid.Cid, error)
+	AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error)
 	GetOwner(ctx context.Context, minerAddr address.Address) (address.Address, error)
 	GetPledge(ctx context.Context, minerAddr address.Address) (*big.Int, error)
 	GetPower(ctx context.Context, minerAddr address.Address) (*big.Int, error)

--- a/api/paych.go
+++ b/api/paych.go
@@ -12,11 +12,11 @@ import (
 
 // Paych is the interface that defines methods to execute payment channel operations.
 type Paych interface {
-	Create(ctx context.Context, fromAddr, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
-	Ls(ctx context.Context, fromAddr, payerAddr address.Address) (map[string]*paymentbroker.PaymentChannel, error)
+	Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
+	Ls(ctx context.Context, fromAddr address.Address, payerAddr address.Address) (map[string]*paymentbroker.PaymentChannel, error)
 	Voucher(ctx context.Context, fromAddr address.Address, channel *types.ChannelID, amount *types.AttoFIL) (string, error)
-	Redeem(ctx context.Context, fromAddr address.Address, voucherRaw string) (cid.Cid, error)
-	Reclaim(ctx context.Context, fromAddr address.Address, channel *types.ChannelID) (cid.Cid, error)
-	Close(ctx context.Context, fromAddr address.Address, voucherRaw string) (cid.Cid, error)
-	Extend(ctx context.Context, fromAddr address.Address, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
+	Redeem(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error)
+	Reclaim(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID) (cid.Cid, error)
+	Close(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error)
+	Extend(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
 }

--- a/api2/impl/plumbing.go
+++ b/api2/impl/plumbing.go
@@ -31,6 +31,6 @@ func New(msgSender *message.Sender) *PlumbingAPI {
 }
 
 // MessageSend implements MessageSend from api2.Message.
-func (p *PlumbingAPI) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) (cid.Cid, error) {
-	return p.msgSender.Send(ctx, from, to, value, method, params...)
+func (p *PlumbingAPI) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error) {
+	return p.msgSender.Send(ctx, from, to, value, gasPrice, gasLimit, method, params...)
 }

--- a/api2/message.go
+++ b/api2/message.go
@@ -12,5 +12,5 @@ import (
 // Message is the message-related Filecoin plumbing interface.
 type Message interface {
 	// MessageSend enqueues a message in the message pool and broadcasts it to the network.
-	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error)
 }

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -5,12 +5,9 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/filecoin-project/go-filecoin/proofs"
 	"math/big"
 	mrand "math/rand"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
@@ -22,11 +19,13 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/repo"
 	"github.com/filecoin-project/go-filecoin/state"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
+	"github.com/stretchr/testify/require"
 )
 
 // MkFakeChild creates a mock child block of a genesis block. If a
@@ -258,22 +257,8 @@ func RequireRandomPeerID() peer.ID {
 	return pid
 }
 
-// MustSign signs a given address with the provided mocksigner or panics if it
-// cannot.
-func MustSign(s types.MockSigner, msgs ...*types.Message) []*types.SignedMessage {
-	var smsgs []*types.SignedMessage
-	for _, m := range msgs {
-		sm, err := types.NewSignedMessage(*m, &s)
-		if err != nil {
-			panic(err)
-		}
-		smsgs = append(smsgs, sm)
-	}
-	return smsgs
-}
-
 func mockSign(sn types.MockSigner, msg *types.Message) *types.SignedMessage {
-	return MustSign(sn, msg)[0]
+	return th.MustSign(sn, msg)[0]
 }
 
 // AddChain creates a new chain of length, beginning from blks, and adds to

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -76,6 +76,8 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 	updateMsg := th.RunSuccessFirstLine(d,
 		"miner", "update-peerid",
 		"--from", addr,
+		"--price", "0",
+		"--limit", "0",
 		minerAddr,
 		minerPidForUpdate.Pretty(),
 	)

--- a/commands/main.go
+++ b/commands/main.go
@@ -2,13 +2,14 @@ package commands
 
 import (
 	"context"
+	"github.com/filecoin-project/go-filecoin/types"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"syscall"
 
-	manet "gx/ipfs/QmQVUtnrNGtCRkCMpXgpApfzQjc8FDaDVxHqWH8cnZQeh5/go-multiaddr-net"
+	"gx/ipfs/QmQVUtnrNGtCRkCMpXgpApfzQjc8FDaDVxHqWH8cnZQeh5/go-multiaddr-net"
 	ma "gx/ipfs/QmRKLtwMw131aK7ugC3G7ybpumMz78YrJe5dzneyindvG1/go-multiaddr"
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 	"gx/ipfs/Qma6uuSyjkecGhMFFLfzyJDPyoDtNJSHJNweDccZhaWkgU/go-ipfs-cmds"
@@ -281,4 +282,29 @@ func isConnectionRefused(err error) bool {
 		return false
 	}
 	return syscallErr.Err == syscall.ECONNREFUSED
+}
+
+var priceOption = cmdkit.StringOption("price", "Price (FIL e.g. 0.00013) to pay for each GasUnit consumed mining this message")
+var limitOption = cmdkit.Int64Option("limit", "Maximum number of GasUnits this message is allowed to consume")
+
+func parseGasOptions(req *cmds.Request) (gasPrice types.AttoFIL, gasCost types.GasCost, error error) {
+	priceOption := req.Options["price"]
+	if priceOption == nil {
+		return types.AttoFIL{}, types.NewGasCost(0), errors.New("price option is required")
+	}
+
+	price, ok := types.NewAttoFILFromFILString(priceOption.(string))
+	if !ok {
+		return types.AttoFIL{}, types.NewGasCost(0), errors.New("invalid gas price (specify FIL as a decimal number)")
+	}
+
+	gasLimitInt, ok := req.Options["limit"].(int64)
+	if !ok {
+		return types.AttoFIL{}, types.NewGasCost(0), errors.New("invalid gas limit")
+	}
+	if gasLimitInt < 0 {
+		return types.AttoFIL{}, types.NewGasCost(0), errors.New("gas limit cannot be less than zero")
+	}
+
+	return *price, types.NewGasCost(gasLimitInt), nil
 }

--- a/commands/message.go
+++ b/commands/message.go
@@ -38,6 +38,8 @@ var msgSendCmd = &cmds.Command{
 	Options: []cmdkit.Option{
 		cmdkit.IntOption("value", "Value to send with message, in AttoFIL"),
 		cmdkit.StringOption("from", "Address to send message from"),
+		priceOption,
+		limitOption,
 		// TODO: (per dignifiedquire) add an option to set the nonce and method explicitly
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
@@ -61,12 +63,17 @@ var msgSendCmd = &cmds.Command{
 			}
 		}
 
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
 		method, ok := req.Options["method"].(string)
 		if !ok {
 			method = ""
 		}
 
-		c, err := GetPlumbingAPI(env).MessageSend(req.Context, fromAddr, target, types.NewAttoFILFromFIL(uint64(val)), method)
+		c, err := GetPlumbingAPI(env).MessageSend(req.Context, fromAddr, target, types.NewAttoFILFromFIL(uint64(val)), gasPrice, gasLimit, method)
 		if err != nil {
 			return err
 		}

--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -28,13 +28,16 @@ func TestMessageSend(t *testing.T) {
 		"invalid checksum",
 		"message", "send",
 		"--from", fixtures.TestAddresses[0],
+		"--price", "0", "--limit", "0",
 		"--value=10", "xyz",
 	)
 
 	t.Log("[success] with from")
 	defaultaddr := d.GetDefaultAddress()
 	d.RunSuccess("message", "send",
-		"--from", fixtures.TestAddresses[0], defaultaddr,
+		"--from", fixtures.TestAddresses[0],
+		"--price", "0", "--limit", "0",
+		defaultaddr,
 	)
 
 	// t.Log("[success] default from")
@@ -43,6 +46,7 @@ func TestMessageSend(t *testing.T) {
 	t.Log("[success] with from and value")
 	d.RunSuccess("message", "send",
 		"--from", fixtures.TestAddresses[0],
+		"--price", "0", "--limit", "0",
 		"--value=10", fixtures.TestAddresses[1],
 	)
 }
@@ -63,6 +67,7 @@ func TestMessageWait(t *testing.T) {
 		msg := d.RunSuccess(
 			"message", "send",
 			"--from", fixtures.TestAddresses[0],
+			"--price", "0", "--limit", "0",
 			"--value=10",
 			fixtures.TestAddresses[1],
 		)

--- a/commands/miner.go
+++ b/commands/miner.go
@@ -70,6 +70,8 @@ Collateral must be greater than 0.001 FIL per pledged sector.`,
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),
 		cmdkit.StringOption("peerid", "Base58-encoded libp2p peer ID that the miner will operate"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		var err error
@@ -98,7 +100,12 @@ Collateral must be greater than 0.001 FIL per pledged sector.`,
 			return ErrInvalidCollateral
 		}
 
-		addr, err := GetAPI(env).Miner().Create(req.Context, fromAddr, pledge, pid, collateral)
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		addr, err := GetAPI(env).Miner().Create(req.Context, fromAddr, gasPrice, gasLimit, pledge, pid, collateral)
 		if err != nil {
 			return err
 		}
@@ -124,6 +131,8 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		minerAddr, err := address.NewFromString(req.Arguments[0])
@@ -141,7 +150,12 @@ var minerUpdatePeerIDCmd = &cmds.Command{
 			return err
 		}
 
-		c, err := GetAPI(env).Miner().UpdatePeerID(req.Context, fromAddr, minerAddr, newPid)
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Miner().UpdatePeerID(req.Context, fromAddr, minerAddr, gasPrice, gasLimit, newPid)
 		if err != nil {
 			return err
 		}
@@ -167,6 +181,8 @@ var minerAddAskCmd = &cmds.Command{
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send the ask from"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		fromAddr, err := optionalAddr(req.Options["from"])
@@ -189,7 +205,12 @@ var minerAddAskCmd = &cmds.Command{
 			return fmt.Errorf("expiry must be a valid integer")
 		}
 
-		c, err := GetAPI(env).Miner().AddAsk(req.Context, fromAddr, minerAddr, price, expiry)
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Miner().AddAsk(req.Context, fromAddr, minerAddr, gasPrice, gasLimit, price, expiry)
 		if err != nil {
 			return err
 		}

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -196,7 +196,7 @@ func TestMinerCreate(t *testing.T) {
 
 			d1.ConnectSuccess(d)
 
-			args := []string{"miner", "create", "--from", fromAddress.String()}
+			args := []string{"miner", "create", "--from", fromAddress.String(), "--price", "0", "--limit", "0"}
 
 			if pid.Pretty() != peer.ID("").Pretty() {
 				args = append(args, "--peerid", pid.Pretty())
@@ -239,23 +239,23 @@ func TestMinerCreate(t *testing.T) {
 
 		d.RunFail("invalid peer id",
 			"miner", "create",
-			"--from", testAddr.String(), "--peerid", "flarp", "1000000", "20",
+			"--from", testAddr.String(), "--price", "0", "--limit", "0", "--peerid", "flarp", "1000000", "20",
 		)
 		d.RunFail("invalid from address",
 			"miner", "create",
-			"--from", "hello", "1000000", "20",
+			"--from", "hello", "--price", "0", "--limit", "0", "1000000", "20",
 		)
 		d.RunFail("invalid pledge",
 			"miner", "create",
-			"--from", testAddr.String(), "'-123'", "20",
+			"--from", testAddr.String(), "--price", "0", "--limit", "0", "'-123'", "20",
 		)
 		d.RunFail("invalid pledge",
 			"miner", "create",
-			"--from", testAddr.String(), "1f", "20",
+			"--from", testAddr.String(), "--price", "0", "--limit", "0", "1f", "20",
 		)
 		d.RunFail("invalid collateral",
 			"miner", "create",
-			"--from", testAddr.String(), "100", "2f",
+			"--from", testAddr.String(), "--price", "0", "--limit", "0", "100", "2f",
 		)
 	})
 
@@ -275,7 +275,7 @@ func TestMinerCreate(t *testing.T) {
 		go func() {
 			d.RunFail("pledge must be at least",
 				"miner", "create",
-				"--from", testAddr.String(), "1", "10",
+				"--from", testAddr.String(), "--price", "0", "--limit", "0", "1", "10",
 			)
 			wg.Done()
 		}()
@@ -301,7 +301,7 @@ func TestMinerCreate(t *testing.T) {
 		go func() {
 			d.RunFail("not enough balance",
 				"miner", "create",
-				"--from", testAddr.String(), "10", "10000000000000000",
+				"--from", testAddr.String(), "--price", "0", "--limit", "0", "10", "10000000000000000",
 			)
 			wg.Done()
 		}()
@@ -324,7 +324,7 @@ func TestMinerAddAskSuccess(t *testing.T) {
 	var minerAddr address.Address
 	wg.Add(1)
 	go func() {
-		miner := d.RunSuccess("miner", "create", "--from", fixtures.TestAddresses[2], "100", "20")
+		miner := d.RunSuccess("miner", "create", "--from", fixtures.TestAddresses[2], "--price", "0", "--limit", "0", "100", "20")
 		addr, err := address.NewFromString(strings.Trim(miner.ReadStdout(), "\n"))
 		assert.NoError(err)
 		assert.NotEqual(addr, address.Address{})
@@ -337,7 +337,7 @@ func TestMinerAddAskSuccess(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		ask := d.RunSuccess("miner", "add-ask", minerAddr.String(), "20", "10",
-			"--from", fixtures.TestAddresses[2],
+			"--from", fixtures.TestAddresses[2], "--price", "0", "--limit", "0",
 		)
 		askCid, err := cid.Parse(strings.Trim(ask.ReadStdout(), "\n"))
 		require.NoError(t, err)
@@ -360,6 +360,7 @@ func TestMinerAddAskFail(t *testing.T) {
 	go func() {
 		miner := d.RunSuccess("miner", "create",
 			"--from", fixtures.TestAddresses[2],
+			"--price", "0", "--limit", "0",
 			"--peerid", th.RequireRandomPeerID().Pretty(),
 			"100", "20",
 		)
@@ -374,23 +375,23 @@ func TestMinerAddAskFail(t *testing.T) {
 	wg.Wait()
 	d.RunFail(
 		"invalid from address",
-		"miner", "add-ask", minerAddr.String(), "20", "10",
+		"miner", "add-ask", minerAddr.String(), "--price", "0", "--limit", "0", "20", "10",
 		"--from", "hello",
 	)
 	d.RunFail(
 		"invalid miner address",
 		"miner", "add-ask", "hello", "20", "10",
-		"--from", fixtures.TestAddresses[2],
+		"--from", fixtures.TestAddresses[2], "--price", "0", "--limit", "0",
 	)
 	d.RunFail(
 		"invalid price",
 		"miner", "add-ask", minerAddr.String(), "2f", "10",
-		"--from", fixtures.TestAddresses[2],
+		"--from", fixtures.TestAddresses[2], "--price", "0", "--limit", "0",
 	)
 	d.RunFail(
 		"expiry must be a valid integer",
 		"miner", "add-ask", minerAddr.String(), "10", "3f",
-		"--from", fixtures.TestAddresses[2],
+		"--from", fixtures.TestAddresses[2], "--price", "0", "--limit", "0",
 	)
 }
 

--- a/commands/mpool_daemon_test.go
+++ b/commands/mpool_daemon_test.go
@@ -25,6 +25,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
+			"--price", "0", "--limit", "0",
 			"--value=10", fixtures.TestAddresses[2],
 		)
 
@@ -54,6 +55,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
+			"--price", "0", "--limit", "0",
 			"--value=10", fixtures.TestAddresses[1],
 		)
 
@@ -61,6 +63,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
+			"--price", "0", "--limit", "0",
 			"--value=10", fixtures.TestAddresses[1],
 		)
 
@@ -68,6 +71,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
+			"--price", "0", "--limit", "0",
 			"--value=10", fixtures.TestAddresses[1],
 		)
 

--- a/commands/payment_channel.go
+++ b/commands/payment_channel.go
@@ -41,6 +41,8 @@ message to be mined to get the channelID.`,
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address to send from"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		fromAddr, err := optionalAddr(req.Options["from"])
@@ -63,7 +65,12 @@ message to be mined to get the channelID.`,
 			return ErrInvalidBlockHeight
 		}
 
-		c, err := GetAPI(env).Paych().Create(req.Context, fromAddr, target, eol, amount)
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Paych().Create(req.Context, fromAddr, gasPrice, gasLimit, target, eol, amount)
 		if err != nil {
 			return err
 		}
@@ -177,6 +184,8 @@ var redeemCmd = &cmds.Command{
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address of the channel target"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		fromAddr, err := optionalAddr(req.Options["from"])
@@ -184,7 +193,12 @@ var redeemCmd = &cmds.Command{
 			return err
 		}
 
-		c, err := GetAPI(env).Paych().Redeem(req.Context, fromAddr, req.Arguments[0])
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Paych().Redeem(req.Context, fromAddr, gasPrice, gasLimit, req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -208,6 +222,8 @@ var reclaimCmd = &cmds.Command{
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address of the channel creator"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		fromAddr, err := optionalAddr(req.Options["from"])
@@ -220,7 +236,12 @@ var reclaimCmd = &cmds.Command{
 			return fmt.Errorf("invalid channel id")
 		}
 
-		c, err := GetAPI(env).Paych().Reclaim(req.Context, fromAddr, channel)
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Paych().Reclaim(req.Context, fromAddr, gasPrice, gasLimit, channel)
 		if err != nil {
 			return err
 		}
@@ -245,6 +266,8 @@ var closeCmd = &cmds.Command{
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address of the channel target"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		fromAddr, err := optionalAddr(req.Options["from"])
@@ -252,7 +275,12 @@ var closeCmd = &cmds.Command{
 			return err
 		}
 
-		c, err := GetAPI(env).Paych().Close(req.Context, fromAddr, req.Arguments[0])
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Paych().Close(req.Context, fromAddr, gasPrice, gasLimit, req.Arguments[0])
 		if err != nil {
 			return err
 		}
@@ -278,6 +306,8 @@ var extendCmd = &cmds.Command{
 	},
 	Options: []cmdkit.Option{
 		cmdkit.StringOption("from", "Address of the channel creator"),
+		priceOption,
+		limitOption,
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		fromAddr, err := optionalAddr(req.Options["from"])
@@ -300,7 +330,12 @@ var extendCmd = &cmds.Command{
 			return ErrInvalidBlockHeight
 		}
 
-		c, err := GetAPI(env).Paych().Extend(req.Context, fromAddr, channel, eol, amount)
+		gasPrice, gasLimit, err := parseGasOptions(req)
+		if err != nil {
+			return err
+		}
+
+		c, err := GetAPI(env).Paych().Extend(req.Context, fromAddr, gasPrice, gasLimit, channel, eol, amount)
 		if err != nil {
 			return err
 		}

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -33,7 +33,7 @@ func TestPaymentChannelCreateSuccess(t *testing.T) {
 	defer d.ShutdownSuccess()
 
 	args := []string{"paych", "create"}
-	args = append(args, "--from", fixtures.TestAddresses[0])
+	args = append(args, "--from", fixtures.TestAddresses[0], "--price", "0", "--limit", "0")
 	args = append(args, fixtures.TestAddresses[1], "10000", "20")
 
 	paymentChannelCmd := d.RunSuccess(args...)
@@ -312,7 +312,7 @@ func daemonTestWithPaymentChannel(t *testing.T, payerAddress *address.Address, t
 	defer d.ShutdownSuccess()
 
 	args := []string{"paych", "create"}
-	args = append(args, "--from", payerAddress.String())
+	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "0")
 	args = append(args, targetAddress.String(), fundsToLock.String(), eol.String())
 
 	paymentChannelCmd := d.RunSuccess(args...)
@@ -375,7 +375,7 @@ func mustExtendChannel(t *testing.T, d *th.TestDaemon, channelID *types.ChannelI
 	require := require.New(t)
 
 	args := []string{"paych", "extend"}
-	args = append(args, "--from", payerAddress.String())
+	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "0")
 	args = append(args, channelID.String(), amount.String(), eol.String())
 
 	redeemCmd := d.RunSuccess(args...)
@@ -405,7 +405,7 @@ func mustRedeemVoucher(t *testing.T, d *th.TestDaemon, voucher string, targetAdd
 	require := require.New(t)
 
 	args := []string{"paych", "redeem", voucher}
-	args = append(args, "--from", targetAddress.String())
+	args = append(args, "--from", targetAddress.String(), "--price", "0", "--limit", "0")
 
 	redeemCmd := d.RunSuccess(args...)
 	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
@@ -434,7 +434,7 @@ func mustCloseChannel(t *testing.T, d *th.TestDaemon, voucher paymentbroker.Paym
 	require := require.New(t)
 
 	args := []string{"paych", "close", mustEncodeVoucherStr(t, voucher)}
-	args = append(args, "--from", targetAddress.String())
+	args = append(args, "--from", targetAddress.String(), "--price", "0", "--limit", "0")
 
 	redeemCmd := d.RunSuccess(args...)
 	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
@@ -463,7 +463,7 @@ func mustReclaimChannel(t *testing.T, d *th.TestDaemon, channelID *types.Channel
 	require := require.New(t)
 
 	args := []string{"paych", "reclaim", channelID.String()}
-	args = append(args, "--from", payerAddress.String())
+	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "0")
 
 	reclaimCmd := d.RunSuccess(args...)
 	messageCid, err := cid.Parse(strings.Trim(reclaimCmd.ReadStdout(), "\n"))

--- a/commands/schema/filecoin_block.schema.json
+++ b/commands/schema/filecoin_block.schema.json
@@ -153,11 +153,19 @@
               "type": "string"
             }
           ]
+        },
+        "gasPrice": {
+          "type": "string"
+        },
+        "gasLimit": {
+          "type": "string"
         }
       },
       "required": [
         "message",
-        "signature"
+        "signature",
+        "gasPrice",
+        "gasLimit"
       ],
       "type": "object"
     },

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -56,7 +56,7 @@ func TestProcessBlockSuccess(t *testing.T) {
 
 	vms := th.VMStorage()
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	blk := &types.Block{
@@ -102,7 +102,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	})
 
 	msg1 := types.NewMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	blk1 := &types.Block{
 		Height:    20,
@@ -111,7 +111,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	}
 
 	msg2 := types.NewMessage(fromAddr2, toAddr, 0, types.NewAttoFILFromFIL(50), "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	blk2 := &types.Block{
 		Height:    20,
@@ -153,7 +153,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 	})
 
 	msg1 := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(501), "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	blk1 := &types.Block{
 		Height:    20,
@@ -163,7 +163,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 	}
 
 	msg2 := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(502), "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	blk2 := &types.Block{
 		Height:    20,
@@ -206,7 +206,7 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 
 	vms := th.VMStorage()
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	// corrupt the message data
 	smsg.Message.Nonce = 13
@@ -361,7 +361,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 		toAddr:   act2,
 	})
 	msg := types.NewMessage(fromAddr, toAddr, 0, nil, "returnRevertError", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	blk := &types.Block{
 		Height:    20,

--- a/consensus/tipset_test.go
+++ b/consensus/tipset_test.go
@@ -30,7 +30,7 @@ func block(require *require.Assertions, height int, parentCid cid.Cid, parentWei
 	addrGetter := address.NewForTestGetter()
 
 	m1 := types.NewMessage(mockSignerForTest.Addresses[0], addrGetter(), 0, types.NewAttoFILFromFIL(10), "hello", []byte(msg))
-	sm1, err := types.NewSignedMessage(*m1, &mockSignerForTest)
+	sm1, err := types.NewSignedMessage(*m1, &mockSignerForTest, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	ret := []byte{1, 2}
 

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -168,11 +168,13 @@ function wait_mpool_size {
 
 function add_ask {
   ./go-filecoin miner add-ask "$1" "$2" "$3" \
+    --price=0 --limit=0 \
     --repodir="$4"
 }
 
 function miner_update_pid {
   ./go-filecoin miner update-peerid "$1" "$2" \
+    --price=0 --limit=0 \
     --repodir="$3"
 }
 

--- a/message/sender.go
+++ b/message/sender.go
@@ -52,7 +52,7 @@ func NewSender(repo repo.Repo, wallet *wallet.Wallet, chainReader chain.ReadStor
 // message using the wallet. This method "sends" in the sense that it enqueues the
 // message in the msg pool and broadcasts it to the network; it does not wait for the
 // message to go on chain.
-func (s *Sender) Send(ctx context.Context, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) (cid.Cid, error) {
+func (s *Sender) Send(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error) {
 	// If the from address isn't set attempt to use the default address.
 	if from == (address.Address{}) {
 		ret, err := GetAndMaybeSetDefaultSenderAddress(s.repo, s.wallet)
@@ -77,7 +77,7 @@ func (s *Sender) Send(ctx context.Context, from, to address.Address, value *type
 	}
 
 	msg := types.NewMessage(from, to, nonce, value, method, encodedParams)
-	smsg, err := types.NewSignedMessage(*msg, s.wallet)
+	smsg, err := types.NewSignedMessage(*msg, s.wallet, gasPrice, gasLimit)
 	if err != nil {
 		return cid.Undef, errors.Wrap(err, "failed to sign message")
 	}

--- a/message/sender_test.go
+++ b/message/sender_test.go
@@ -60,7 +60,7 @@ func TestSend(t *testing.T) {
 
 		s := NewSender(repo, w, chainStore, msgPool, publish)
 		require.Equal(0, len(msgPool.Pending()))
-		_, err = s.Send(context.Background(), addr, addr, types.NewAttoFILFromFIL(uint64(2)), "")
+		_, err = s.Send(context.Background(), addr, addr, types.NewAttoFILFromFIL(uint64(2)), types.NewGasPrice(0), types.NewGasCost(0), "")
 		require.NoError(err)
 		assert.Equal(1, len(msgPool.Pending()))
 		assert.True(publishCalled)
@@ -81,7 +81,7 @@ func TestSend(t *testing.T) {
 		addTwentyMessages := func(batch int) {
 			defer wg.Done()
 			for i := 0; i < 20; i++ {
-				_, err := s.Send(ctx, addr, addr, types.NewZeroAttoFIL(), fmt.Sprintf("%d-%d", batch, i), []byte{})
+				_, err := s.Send(ctx, addr, addr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasCost(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
 				require.NoError(err)
 			}
 		}
@@ -134,7 +134,7 @@ func TestNextNonce(t *testing.T) {
 
 		msg := types.NewMessage(addr, addr, 0, nil, "foo", []byte{})
 		msg.Nonce = 42
-		smsg, err := types.NewSignedMessage(*msg, w)
+		smsg, err := types.NewSignedMessage(*msg, w, types.NewGasPrice(0), types.NewGasCost(0))
 		assert.NoError(err)
 		core.MustAdd(msgPool, smsg)
 

--- a/message/waiter_test.go
+++ b/message/waiter_test.go
@@ -147,11 +147,11 @@ func TestWaitConflicting(t *testing.T) {
 
 	// Create conflicting messages
 	m1 := types.NewMessage(addr1, addr3, 0, types.NewAttoFILFromFIL(6000), "", nil)
-	sm1, err := types.NewSignedMessage(*m1, &mockSigner)
+	sm1, err := types.NewSignedMessage(*m1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	m2 := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(6000), "", nil)
-	sm2, err := types.NewSignedMessage(*m2, &mockSigner)
+	sm2, err := types.NewSignedMessage(*m2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	baseTS := chainStore.Head()

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -45,6 +45,8 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	srewardMsg := &types.SignedMessage{
 		Message:   *rewardMsg,
 		Signature: nil,
+		GasPrice:  types.NewGasPrice(0),
+		GasLimit:  types.NewGasCost(0),
 	}
 
 	pending := w.messagePool.Pending()

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -145,21 +145,21 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	// exercise the categorization.
 	// addr2 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addr2, addr1, 0, nil, "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	// This is actually okay and should result in a receipt
 	msg2 := types.NewMessage(addr1, addr2, 0, nil, "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	// The following two are sending to self -- errSelfSend, a permanent error.
 	msg3 := types.NewMessage(addr1, addr1, 1, nil, "", nil)
-	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner)
+	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	msg4 := types.NewMessage(addr2, addr2, 1, nil, "", nil)
-	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner)
+	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	messages := []*types.SignedMessage{smsg1, smsg2, smsg3, smsg4}
@@ -230,21 +230,21 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, nil, "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner)
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	// This is actually okay and should result in a receipt
 	msg2 := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner)
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	// The following two are sending to self -- errSelfSend, a permanent error.
 	msg3 := types.NewMessage(addrs[0], addrs[0], 1, nil, "", nil)
-	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner)
+	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	msg4 := types.NewMessage(addrs[1], addrs[1], 0, nil, "", nil)
-	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner)
+	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	pool.Add(smsg1)
@@ -352,7 +352,7 @@ func TestGenerateError(t *testing.T) {
 
 	// This is actually okay and should result in a receipt
 	msg := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner)
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 	pool.Add(smsg)
 

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -34,7 +34,9 @@ func TestMessagePropagation(t *testing.T) {
 	nd0Addr, err := nodes[0].NewAddress()
 	require.NoError(err)
 
-	_, err = nodes[0].PlumbingAPI.MessageSend(ctx, nd0Addr, address.NetworkAddress, types.NewAttoFILFromFIL(123), "")
+	gasPrice := types.NewGasPrice(0)
+	gasLimit := types.NewGasCost(0)
+	_, err = nodes[0].PlumbingAPI.MessageSend(ctx, nd0Addr, address.NetworkAddress, types.NewAttoFILFromFIL(123), gasPrice, gasLimit, "")
 	require.NoError(err)
 
 	// Wait for message to propagate across network

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -397,7 +397,9 @@ func TestSendMessage(t *testing.T) {
 
 		assert.NoError(node.Start(ctx))
 
-		_, err = node.PlumbingAPI.MessageSend(ctx, nodeAddr, nodeAddr, types.NewZeroAttoFIL(), "foo", []byte{})
+		gasPrice := types.NewGasPrice(0)
+		gasLimit := types.NewGasCost(0)
+		_, err = node.PlumbingAPI.MessageSend(ctx, nodeAddr, nodeAddr, types.NewZeroAttoFIL(), gasPrice, gasLimit, "foo", []byte{})
 		require.NoError(err)
 
 		assert.Equal(1, len(node.MsgPool.Pending()))

--- a/node/testing.go
+++ b/node/testing.go
@@ -345,7 +345,7 @@ func RunCreateMiner(t *testing.T, node *Node, from address.Address, pledge uint6
 	require.NoError(err)
 
 	go func() {
-		minerAddr, err := node.CreateMiner(ctx, from, pledge, pid, &collateral)
+		minerAddr, err := node.CreateMiner(ctx, from, types.NewGasPrice(0), types.NewGasCost(0), pledge, pid, &collateral)
 		resultChan <- MustCreateMinerResult{MinerAddress: minerAddr, Err: err}
 		wg.Done()
 	}()

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -446,7 +446,7 @@ func (td *TestDaemon) CreateMinerAddr(peer *TestDaemon, fromAddr string) address
 	var minerAddr address.Address
 	wg.Add(1)
 	go func() {
-		miner := td.RunSuccess("miner", "create", "--from", fromAddr, "100", "20")
+		miner := td.RunSuccess("miner", "create", "--from", fromAddr, "--price", "0", "--limit", "0", "100", "20")
 		addr, err := address.NewFromString(strings.Trim(miner.ReadStdout(), "\n"))
 		require.NoError(err)
 		require.NotEqual(addr, address.Address{})
@@ -466,7 +466,7 @@ func (td *TestDaemon) CreateAsk(peer *TestDaemon, minerAddr string, fromAddr str
 	wg.Add(1)
 
 	go func() {
-		ask := td.RunSuccess("miner", "add-ask", "--from", fromAddr, minerAddr, price, expiry)
+		ask := td.RunSuccess("miner", "add-ask", "--from", fromAddr, "--price", "0", "--limit", "0", minerAddr, price, expiry)
 		askCid, err := cid.Parse(strings.Trim(ask.ReadStdout(), "\n"))
 		require.NoError(td.test, err)
 		assert.NotNil(td.test, askCid)

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -102,7 +102,7 @@ func VMStorage() vm.StorageMap {
 func MustSign(s types.MockSigner, msgs ...*types.Message) []*types.SignedMessage {
 	var smsgs []*types.SignedMessage
 	for _, m := range msgs {
-		sm, err := types.NewSignedMessage(*m, &s)
+		sm, err := types.NewSignedMessage(*m, &s, types.NewGasPrice(0), types.NewGasCost(0))
 		if err != nil {
 			panic(err)
 		}

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -91,7 +91,7 @@ func MustImportGenesisMiner(tn *TestNode, gi *GenesisInfo) {
 	tn.MustRunCmdJSON(ctx, &id, "go-filecoin", "id")
 
 	// Update miner
-	tn.MustRunCmd(ctx, "go-filecoin", "miner", "update-peerid", "--from="+gi.WalletAddress, gi.MinerAddress, id.ID)
+	tn.MustRunCmd(ctx, "go-filecoin", "miner", "update-peerid", "--from="+gi.WalletAddress, "--price=0", "--limit=0", gi.MinerAddress, id.ID)
 }
 
 // MustInitWithGenesis init TestNode, passing in the `--genesisfile` flag, by calling MustInit

--- a/tools/faucet/main.go
+++ b/tools/faucet/main.go
@@ -81,7 +81,7 @@ func main() {
 			return
 		}
 
-		reqStr := fmt.Sprintf("http://%s/api/message/send?arg=%s&value=%d&from=%s", *filapi, addr.String(), *faucetval, *filwal)
+		reqStr := fmt.Sprintf("http://%s/api/message/send?arg=%s&value=%d&from=%s&price=0&limit=0", *filapi, addr.String(), *faucetval, *filwal)
 		log.Infof("Request URL: %s", reqStr)
 
 		resp, err := http.Post(reqStr, "application/json", nil)

--- a/tools/iptb-plugins/filecoin/local/scripts/prepMining.sh
+++ b/tools/iptb-plugins/filecoin/local/scripts/prepMining.sh
@@ -48,7 +48,7 @@ ownerRaw=$(iptb run 0 -- go-filecoin wallet import "$FIXDIR/0.key")
 minerOwner=$(echo $ownerRaw | sed -e 's/^node\[0\] exit 0 //' | jq -r ".")
 # update the peerID to the correct value
 peerID=$(iptb run 0 -- go-filecoin id | tail -n +3 | jq ".ID" -r)
-iptb run 0 -- go-filecoin miner update-peerid --from="$minerOwner" "$minerAddr" "$peerID"
+iptb run 0 -- go-filecoin miner update-peerid --from="$minerOwner" --price=0 --limit=0 "$minerAddr" "$peerID"
 # start mining
 iptb run 0 -- go-filecoin mining start
 
@@ -86,7 +86,7 @@ do
 
     # add an ask
     printf "adding ask"
-    iptb run "$i" -- go-filecoin miner add-ask "$newMinerAddr" 1 100000 # price of one FIL/whatever, ask is valid for 100000 blocks
+    iptb run "$i" -- go-filecoin miner add-ask "$newMinerAddr" 1 100000 --price=0 --limit=0 # price of one FIL/whatever, ask is valid for 100000 blocks
 
     # make a deal
     dd if=/dev/random of="$FIXDIR/fake.dat"  bs="$DD_FILE_SIZE"  count=1 # small data file will be autosealed

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -1,12 +1,17 @@
 package types
 
 import (
+	"math/big"
+
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 
 	"github.com/filecoin-project/go-filecoin/address"
 )
+
+// GasCost represents a unit of gas consumed
+type GasCost = Uint64
 
 var (
 	// ErrMessageSigned is returned when `Sign()` is called on a signedmessage that has previously been signed
@@ -27,6 +32,8 @@ func init() {
 type SignedMessage struct {
 	Message   `json:"message"`
 	Signature Signature `json:"signature"`
+	GasPrice  AttoFIL   `json:"gasPrice"`
+	GasLimit  GasCost   `json:"gasLimit"`
 }
 
 // Unmarshal a SignedMessage from the given bytes.
@@ -85,7 +92,7 @@ func (smsg *SignedMessage) VerifySignature() bool {
 
 // NewSignedMessage accepts a message `msg` and a signer `s`. NewSignedMessage returns a `SignedMessage` containing
 // a signature derived from the seralized `msg` and `msg.From`
-func NewSignedMessage(msg Message, s Signer) (*SignedMessage, error) {
+func NewSignedMessage(msg Message, s Signer, gasPrice AttoFIL, gasLimit GasCost) (*SignedMessage, error) {
 	bmsg, err := msg.Marshal()
 	if err != nil {
 		return nil, err
@@ -99,5 +106,17 @@ func NewSignedMessage(msg Message, s Signer) (*SignedMessage, error) {
 	return &SignedMessage{
 		Message:   msg,
 		Signature: sig,
+		GasPrice:  gasPrice,
+		GasLimit:  gasLimit,
 	}, nil
+}
+
+// NewGasPrice constructs a gas price (in AttoFIL) from the given number.
+func NewGasPrice(price int64) AttoFIL {
+	return *NewAttoFIL(big.NewInt(price))
+}
+
+// NewGasCost constructs a new GasCost from the given number.
+func NewGasCost(cost int64) GasCost {
+	return Uint64(cost)
 }

--- a/types/testing.go
+++ b/types/testing.go
@@ -3,6 +3,7 @@ package types
 import (
 	"crypto/ecdsa"
 	"fmt"
+
 	"github.com/stretchr/testify/assert"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -94,7 +95,7 @@ func NewSignedMessageForTestGetter(ms MockSigner) func() *SignedMessage {
 			NewAttoFILFromFIL(0),
 			s,
 			[]byte("params"))
-		smsg, err := NewSignedMessage(*msg, &ms)
+		smsg, err := NewSignedMessage(*msg, &ms, NewGasPrice(0), NewGasCost(0))
 		if err != nil {
 			panic(err)
 		}
@@ -191,7 +192,7 @@ func NewSignedMsgs(n int, ms MockSigner) []*SignedMessage {
 func SignMsgs(ms MockSigner, msgs []*Message) ([]*SignedMessage, error) {
 	var smsgs []*SignedMessage
 	for _, m := range msgs {
-		s, err := NewSignedMessage(*m, &ms)
+		s, err := NewSignedMessage(*m, &ms, NewGasPrice(0), NewGasCost(0))
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/signature_test.go
+++ b/wallet/signature_test.go
@@ -116,7 +116,7 @@ func TestSignMessageOk(t *testing.T) {
 	fs, addr := requireSignerAddr(require)
 
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, fs)
+	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	assert.True(smsg.VerifySignature())
@@ -152,7 +152,7 @@ func TestSignedMessageBadSignature(t *testing.T) {
 
 	fs, addr := requireSignerAddr(require)
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, fs)
+	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	smsg.Signature[0] = smsg.Signature[0] ^ 0xFF
@@ -167,7 +167,7 @@ func TestSignedMessageCorrupted(t *testing.T) {
 	fs, addr := requireSignerAddr(require)
 
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, fs)
+	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasCost(0))
 	require.NoError(err)
 
 	smsg.Message.Nonce = types.Uint64(uint64(42))


### PR DESCRIPTION
closes #910

# Problem
We need to allow miners to charge message senders for processing messages. To lay the groundwork for that, we need to introduce gas price and gas limits to incoming messages.


# Solution
This PR adds `GasPrice` and `GasLimit` to `SignedMessage`. We add it to`SignedMessage` rather than `Message` because we only charge for messages sent over the network, which are also the messages that are signed. It also adds parameters to the API functions that send message, and command line options to the commands that call those API methods.

# Decisions
This PR involved making a few choices about implementation:

1. We default all gas limits to zero. This will cause messages to fail once we implement the charging logic. We would rather set the value low, let it fail, and then decide what to do about it, than allowing an unreasonably high limit to cause problems later.
2. We've implemented the gas price as '--price' and the gas limit as '--limit' in the commands.
3. Gas price is represented as `AttoFIL`. This appears on chain and in various other serialization, so the exiting type gives us a good encoding (leb128).
4. Gas limit (which is a cost) is represented as `Uint64` and is aliased as `GasCost`. Uint64 was chosen for reasons similar to the above.