### PR TITLE
Limit Weight Precision #1483

### DIFF
--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -39,10 +39,10 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 	getState := func(ctx context.Context, ts consensus.TipSet) (state.Tree, error) {
 		return getStateByKey(ctx, ts.String())
 	}
-	getWeight := func(ctx context.Context, ts consensus.TipSet) (uint64, uint64, error) {
+	getWeight := func(ctx context.Context, ts consensus.TipSet) (uint64, error) {
 		parent, err := ts.Parents()
 		if err != nil {
-			return uint64(0), uint64(0), err
+			return uint64(0), err
 		}
 		// TODO handle genesis cid more gracefully
 		if parent.Len() == 0 {
@@ -50,7 +50,7 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 		}
 		pSt, err := getStateByKey(ctx, parent.String())
 		if err != nil {
-			return uint64(0), uint64(0), err
+			return uint64(0), err
 		}
 		return nd.Consensus.Weight(ctx, ts, pSt)
 	}

--- a/chain/default_syncer.go
+++ b/chain/default_syncer.go
@@ -232,26 +232,15 @@ func (syncer *DefaultSyncer) syncOne(ctx context.Context, parent, next consensus
 		}
 	}
 
-	cmp, err := syncer.consensus.IsHeavier(ctx, next, syncer.chainStore.Head(), nextParentSt, headParentSt)
-	if err != nil {
-		return err
-	}
-	nextH, err := next.Height()
-	if err != nil {
-		return err
-	}
-	headH, err := syncer.chainStore.Head().Height()
+	heavier, err := syncer.consensus.IsHeavier(ctx, next, syncer.chainStore.Head(), nextParentSt, headParentSt)
 	if err != nil {
 		return err
 	}
 
-	if cmp > 0 {
-		logSyncer.Debugf("New TS %s (h=%d) is new heaviest over %s (h=%d), update head", next.String(), nextH, syncer.chainStore.Head(), headH)
+	if heavier {
 		if err = syncer.chainStore.SetHead(ctx, next); err != nil {
 			return err
 		}
-	} else {
-		logSyncer.Debugf("New TS %s (h=%d) is not heavier than %s (h=%d), no head update", next.String(), nextH, syncer.chainStore.Head().String(), headH)
 	}
 
 	return nil

--- a/chain/default_syncer_test.go
+++ b/chain/default_syncer_test.go
@@ -738,11 +738,10 @@ func TestTipSetWeightDeep(t *testing.T) {
 	//  w({f1b1, f2b1})   = sw + 0   + 11 * 2  = sw + 22
 	//  w({f1b2a, f1b2b}) = sw + 11  + 11 * 2  = sw + 33
 	//  w({f2b2})         = sw + 11  + 108 	   = sw + 119
-	startingWeightN, startingWeightD, err := con.Weight(ctx, baseTS, pSt)
+	startingWeight, err := con.Weight(ctx, baseTS, pSt)
 	require.NoError(err)
-	require.Equal(uint64(1), startingWeightD)
 
-	wFun := func(ts consensus.TipSet) (uint64, uint64, error) {
+	wFun := func(ts consensus.TipSet) (uint64, error) {
 		// No power-altering messages processed from here on out.
 		// And so bootstrapSt correctly retrives power table for all
 		// test blocks.
@@ -759,10 +758,9 @@ func TestTipSetWeightDeep(t *testing.T) {
 	err = syncer.HandleNewBlocks(ctx, sharedCids)
 	require.NoError(err)
 	assertHead(assert, chain, tsShared)
-	measuredWeight, denom, err := wFun(chain.Head())
+	measuredWeight, err := wFun(chain.Head())
 	require.NoError(err)
-	require.Equal(uint64(1), denom)
-	expectedWeight := startingWeightN + uint64(22)
+	expectedWeight := startingWeight + uint64(22000)
 	assert.Equal(expectedWeight, measuredWeight)
 
 	// fork 1 is heavier than the old head.
@@ -775,10 +773,9 @@ func TestTipSetWeightDeep(t *testing.T) {
 	err = syncer.HandleNewBlocks(ctx, f1Cids)
 	require.NoError(err)
 	assertHead(assert, chain, f1)
-	measuredWeight, denom, err = wFun(chain.Head())
+	measuredWeight, err = wFun(chain.Head())
 	require.NoError(err)
-	require.Equal(uint64(1), denom)
-	expectedWeight = startingWeightN + uint64(33)
+	expectedWeight = startingWeight + uint64(33000)
 	assert.Equal(expectedWeight, measuredWeight)
 
 	// fork 2 has heavier weight because of addr3's power even though there
@@ -790,9 +787,8 @@ func TestTipSetWeightDeep(t *testing.T) {
 	err = syncer.HandleNewBlocks(ctx, f2Cids)
 	require.NoError(err)
 	assertHead(assert, chain, f2)
-	measuredWeight, denom, err = wFun(chain.Head())
+	measuredWeight, err = wFun(chain.Head())
 	require.NoError(err)
-	require.Equal(uint64(1), denom)
-	expectedWeight = startingWeightN + uint64(119)
+	expectedWeight = startingWeight + uint64(119000)
 	assert.Equal(expectedWeight, measuredWeight)
 }

--- a/commands/block.go
+++ b/commands/block.go
@@ -24,7 +24,7 @@ var showCmd = &cmds.Command{
 var showBlockCmd = &cmds.Command{
 	Helptext: cmdkit.HelpText{
 		Tagline: "Show a filecoin block by its CID",
-		ShortDescription: `Prints the miner, parent weight numerator, parent weight denominator, height,
+		ShortDescription: `Prints the miner, parent weight, height,
 and nonce of a given block. If JSON encoding is specified with the --enc flag,
 all other block properties will be included as well.`,
 	},
@@ -47,16 +47,19 @@ all other block properties will be included as well.`,
 	Type: types.Block{},
 	Encoders: cmds.EncoderMap{
 		cmds.Text: cmds.MakeTypedEncoder(func(req *cmds.Request, w io.Writer, block *types.Block) error {
-			_, err := fmt.Fprintf(w, `Block Details
-Miner:       %s
-Numerator:   %s
-Denominator: %s
-Height:      %s
-Nonce:       %s
+			wStr, err := types.FixedStr(uint64(block.ParentWeight))
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(w, `Block Details
+Miner:  %s
+Weight: %s
+Height: %s
+Nonce:  %s
 `,
 				block.Miner,
-				strconv.FormatUint(uint64(block.ParentWeightNum), 10),
-				strconv.FormatUint(uint64(block.ParentWeightDenom), 10),
+				wStr,
 				strconv.FormatUint(uint64(block.Height), 10),
 				strconv.FormatUint(uint64(block.Nonce), 10),
 			)

--- a/commands/block_daemon_test.go
+++ b/commands/block_daemon_test.go
@@ -27,10 +27,9 @@ func TestBlockDaemon(t *testing.T) {
 		output := d.RunSuccess("show", "block", minedBlockCidStr).ReadStdoutTrimNewlines()
 
 		assert.Contains(output, "Block Details")
-		assert.Contains(output, "Numerator:   0")
-		assert.Contains(output, "Denominator: 1")
-		assert.Contains(output, "Height:      1")
-		assert.Contains(output, "Nonce:       0")
+		assert.Contains(output, "Weight: 0")
+		assert.Contains(output, "Height: 1")
+		assert.Contains(output, "Nonce:  0")
 	})
 
 	t.Run("show block <cid-of-genesis-block> --enc json returns JSON for a filecoin block", func(t *testing.T) {

--- a/commands/schema/filecoin_block.schema.json
+++ b/commands/schema/filecoin_block.schema.json
@@ -44,10 +44,7 @@
             "null"
           ]
         },
-        "parentWeightNumerator": {
-          "type": "string"
-        },
-        "parentWeightDenominator": {
+        "parentWeight": {
           "type": "string"
         },
         "proof": {

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -29,10 +29,10 @@ type Protocol interface {
 	// blocks were mined according to protocol rules (RunStateTransition does these checks).
 	NewValidTipSet(ctx context.Context, blks []*types.Block) (TipSet, error)
 	// Weight returns the weight given to the input ts by this consensus protocol.
-	Weight(ctx context.Context, ts TipSet, pSt state.Tree) (uint64, uint64, error)
+	Weight(ctx context.Context, ts TipSet, pSt state.Tree) (uint64, error)
 	// IsHeaver returns 1 if tipset a is heavier than tipset b and -1 if
 	// tipset b is heavier than tipset a.
-	IsHeavier(ctx context.Context, a, b TipSet, aSt, bSt state.Tree) (int, error)
+	IsHeavier(ctx context.Context, a, b TipSet, aSt, bSt state.Tree) (bool, error)
 	// RunStateTransition returns the state resulting from applying the input ts to the parent
 	// state pSt.  It returns an error if the transition is invalid.
 	RunStateTransition(ctx context.Context, ts TipSet, parentTs TipSet, pSt state.Tree) (state.Tree, error)

--- a/consensus/tipset.go
+++ b/consensus/tipset.go
@@ -57,7 +57,7 @@ func (ts TipSet) AddBlock(b *types.Block) error {
 	if err != nil {
 		return err
 	}
-	wNum, wDenom, err := ts.ParentWeight()
+	weight, err := ts.ParentWeight()
 	if err != nil {
 		return err
 	}
@@ -67,8 +67,8 @@ func (ts TipSet) AddBlock(b *types.Block) error {
 	if !b.Parents.Equals(p) {
 		return errors.Errorf("block parents %s don't match tipset parents %s", b.Parents.String(), p.String())
 	}
-	if uint64(b.ParentWeightNum) != wNum || uint64(b.ParentWeightDenom) != wDenom {
-		return errors.Errorf("bBlock parent weight num:%d denom:%d doesn't match existing tipset parent weight num:%d denom:%d", uint64(b.ParentWeightNum), uint64(b.ParentWeightDenom), wNum, wDenom)
+	if uint64(b.ParentWeight) != weight {
+		return errors.Errorf("bBlock parent weight: %d doesn't match existing tipset parent weight: %d", uint64(b.ParentWeight), weight)
 	}
 
 	id := b.Cid()
@@ -152,10 +152,10 @@ func (ts TipSet) Parents() (types.SortedCidSet, error) {
 	return ts.ToSlice()[0].Parents, nil
 }
 
-// ParentWeight returns the tipset's ParentWeightNum and ParentWeightDen.
-func (ts TipSet) ParentWeight() (uint64, uint64, error) {
+// ParentWeight returns the tipset's ParentWeight in fixed point form.
+func (ts TipSet) ParentWeight() (uint64, error) {
 	if len(ts) == 0 {
-		return uint64(0), uint64(0), ErrEmptyTipSet
+		return uint64(0), ErrEmptyTipSet
 	}
-	return uint64(ts.ToSlice()[0].ParentWeightNum), uint64(ts.ToSlice()[0].ParentWeightDenom), nil
+	return uint64(ts.ToSlice()[0].ParentWeight), nil
 }

--- a/consensus/tipset_test.go
+++ b/consensus/tipset_test.go
@@ -35,14 +35,13 @@ func block(require *require.Assertions, height int, parentCid cid.Cid, parentWei
 	ret := []byte{1, 2}
 
 	return &types.Block{
-		Parents:           types.NewSortedCidSet(parentCid),
-		ParentWeightNum:   types.Uint64(parentWeight),
-		ParentWeightDenom: types.Uint64(uint64(1)),
-		Height:            types.Uint64(42 + uint64(height)),
-		Nonce:             7,
-		Messages:          []*types.SignedMessage{sm1},
-		StateRoot:         types.SomeCid(),
-		MessageReceipts:   []*types.MessageReceipt{{ExitCode: 1, Return: []types.Bytes{ret}}},
+		Parents:         types.NewSortedCidSet(parentCid),
+		ParentWeight:    types.Uint64(parentWeight),
+		Height:          types.Uint64(42 + uint64(height)),
+		Nonce:           7,
+		Messages:        []*types.SignedMessage{sm1},
+		StateRoot:       types.SomeCid(),
+		MessageReceipts: []*types.MessageReceipt{{ExitCode: 1, Return: []types.Bytes{ret}}},
 	}
 }
 
@@ -85,7 +84,7 @@ func TestTipSet(t *testing.T) {
 func RequireTestBlocks(t *testing.T) (*types.Block, *types.Block, *types.Block) {
 	require := require.New(t)
 
-	pW := uint64(1337)
+	pW := uint64(1337000)
 
 	b1 := block(require, 1, cid1, pW, "1")
 	b1.Ticket = []byte{0}
@@ -134,7 +133,7 @@ func TestTipSetAddBlock(t *testing.T) {
 	b2.Parents = b1.Parents
 
 	// Invalid weight
-	b2.ParentWeightNum = types.Uint64(3)
+	b2.ParentWeight = types.Uint64(3000)
 	ts = TipSet{}
 	RequireTipSetAdd(require, b1, ts)
 	err = ts.AddBlock(b2)
@@ -168,7 +167,7 @@ func TestNewTipSet(t *testing.T) {
 	b1.Parents = b2.Parents
 
 	// Invalid parent weights
-	b1.ParentWeightNum = types.Uint64(3)
+	b1.ParentWeight = types.Uint64(3000)
 	ts, err = NewTipSet(b1, b2, b3)
 	assert.Error(err)
 	assert.Nil(ts)
@@ -202,10 +201,9 @@ func TestTipSetParents(t *testing.T) {
 func TestTipSetParentWeight(t *testing.T) {
 	assert := assert.New(t)
 	ts := RequireTestTipSet(t)
-	wNum, wDenom, err := ts.ParentWeight()
+	w, err := ts.ParentWeight()
 	assert.NoError(err)
-	assert.Equal(wNum, uint64(1337))
-	assert.Equal(wDenom, uint64(1))
+	assert.Equal(w, uint64(1337000))
 }
 
 func TestTipSetToSortedCidSet(t *testing.T) {

--- a/metrics/heartbeat_test.go
+++ b/metrics/heartbeat_test.go
@@ -162,15 +162,14 @@ func TestHeartbeatRunSuccess(t *testing.T) {
 
 func mustMakeTipset(t *testing.T, height types.Uint64) consensus.TipSet {
 	ts, err := consensus.NewTipSet(&types.Block{
-		Miner:             address.NewForTestGetter()(),
-		Ticket:            nil,
-		Parents:           types.SortedCidSet{},
-		ParentWeightNum:   0,
-		ParentWeightDenom: 0,
-		Height:            types.Uint64(height),
-		Nonce:             0,
-		Messages:          nil,
-		MessageReceipts:   nil,
+		Miner:           address.NewForTestGetter()(),
+		Ticket:          nil,
+		Parents:         types.SortedCidSet{},
+		ParentWeight:    0,
+		Height:          types.Uint64(height),
+		Nonce:           0,
+		Messages:        nil,
+		MessageReceipts: nil,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/mining/block_generate.go
+++ b/mining/block_generate.go
@@ -30,7 +30,7 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 		return nil, errors.Errorf("bad miner address, miner must store files before mining: %s", w.minerAddr)
 	}
 
-	wNum, wDenom, err := w.getWeight(ctx, baseTipSet)
+	weight, err := w.getWeight(ctx, baseTipSet)
 	if err != nil {
 		return nil, errors.Wrap(err, "get weight")
 	}
@@ -76,15 +76,14 @@ func (w *DefaultWorker) Generate(ctx context.Context,
 	}
 
 	next := &types.Block{
-		Miner:             w.minerAddr,
-		Height:            types.Uint64(blockHeight),
-		Messages:          res.SuccessfulMessages,
-		MessageReceipts:   receipts,
-		Parents:           baseTipSet.ToSortedCidSet(),
-		ParentWeightNum:   types.Uint64(wNum),
-		ParentWeightDenom: types.Uint64(wDenom),
-		StateRoot:         newStateTreeCid,
-		Ticket:            ticket,
+		Miner:           w.minerAddr,
+		Height:          types.Uint64(blockHeight),
+		Messages:        res.SuccessfulMessages,
+		MessageReceipts: receipts,
+		Parents:         baseTipSet.ToSortedCidSet(),
+		ParentWeight:    types.Uint64(weight),
+		StateRoot:       newStateTreeCid,
+		Ticket:          ticket,
 	}
 
 	var rewardSuccessful bool

--- a/mining/worker.go
+++ b/mining/worker.go
@@ -53,7 +53,7 @@ type GetStateTree func(context.Context, consensus.TipSet) (state.Tree, error)
 
 // GetWeight is a function that calculates the weight of a TipSet.  Weight is
 // expressed as two uint64s comprising a rational number.
-type GetWeight func(context.Context, consensus.TipSet) (uint64, uint64, error)
+type GetWeight func(context.Context, consensus.TipSet) (uint64, error)
 
 type miningApplier func(ctx context.Context, messages []*types.SignedMessage, st state.Tree, vms vm.StorageMap, bh *types.BlockHeight) (consensus.ApplyMessagesResponse, error)
 

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -194,24 +194,24 @@ func TestGenerateMultiBlockTipSet(t *testing.T) {
 	parents := types.NewSortedCidSet(newCid())
 	stateRoot := newCid()
 	baseBlock1 := types.Block{
-		Parents:         parents,
-		Height:          types.Uint64(100),
-		ParentWeightNum: types.Uint64(1000),
-		StateRoot:       stateRoot,
+		Parents:      parents,
+		Height:       types.Uint64(100),
+		ParentWeight: types.Uint64(1000),
+		StateRoot:    stateRoot,
 	}
 	baseBlock2 := types.Block{
-		Parents:         parents,
-		Height:          types.Uint64(100),
-		ParentWeightNum: types.Uint64(1000),
-		StateRoot:       stateRoot,
-		Nonce:           1,
+		Parents:      parents,
+		Height:       types.Uint64(100),
+		ParentWeight: types.Uint64(1000),
+		StateRoot:    stateRoot,
+		Nonce:        1,
 	}
 	blk, err := worker.Generate(ctx, consensus.RequireNewTipSet(require, &baseBlock1, &baseBlock2), nil, 0)
 	assert.NoError(err)
 
 	assert.Len(blk.Messages, 1) // This is the mining reward.
 	assert.Equal(types.Uint64(101), blk.Height)
-	assert.Equal(types.Uint64(1020), blk.ParentWeightNum)
+	assert.Equal(types.Uint64(1020), blk.ParentWeight)
 }
 
 // After calling Generate, do the new block and new state of the message pool conform to our expectations?
@@ -288,13 +288,11 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	worker := NewDefaultWorker(pool, getStateTree, getWeightTest, consensus.ApplyMessages, &consensus.TestView{}, bs, cst, addrs[3], th.BlockTimeTest)
 
 	h := types.Uint64(100)
-	wNum := types.Uint64(1000)
-	wDenom := types.Uint64(1)
+	w := types.Uint64(1000)
 	baseBlock := types.Block{
-		Height:            h,
-		ParentWeightNum:   wNum,
-		ParentWeightDenom: wDenom,
-		StateRoot:         newCid(),
+		Height:       h,
+		ParentWeight: w,
+		StateRoot:    newCid(),
 	}
 	baseTipSet := consensus.RequireNewTipSet(require, &baseBlock)
 	blk, err := worker.Generate(ctx, baseTipSet, nil, 0)
@@ -307,8 +305,7 @@ func TestGenerateSetsBasicFields(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Equal(h+2, blk.Height)
-	assert.Equal(wNum+10.0, blk.ParentWeightNum)
-	assert.Equal(wDenom, blk.ParentWeightDenom)
+	assert.Equal(w+10.0, blk.ParentWeight)
 	assert.Equal(addrs[3], blk.Miner)
 }
 
@@ -387,12 +384,12 @@ func (st *StateTreeForTest) Flush(ctx context.Context) (cid.Cid, error) {
 	return st.TestFlush(ctx)
 }
 
-func getWeightTest(c context.Context, ts consensus.TipSet) (uint64, uint64, error) {
-	num, den, err := ts.ParentWeight()
+func getWeightTest(c context.Context, ts consensus.TipSet) (uint64, error) {
+	w, err := ts.ParentWeight()
 	if err != nil {
-		return uint64(0), uint64(0), err
+		return uint64(0), err
 	}
-	return num + uint64(int64(len(ts))*int64(consensus.ECV)), den, nil
+	return w + uint64(len(ts))*consensus.ECV, nil
 }
 
 func makeExplodingGetStateTree(st state.Tree) func(context.Context, consensus.TipSet) (state.Tree, error) {

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -53,11 +53,10 @@ func TestBlockPropTwoNodes(t *testing.T) {
 	baseTS := nodes[0].ChainReader.Head()
 	assert.NotNil(t, baseTS)
 	nextBlk := &types.Block{
-		Parents:           baseTS.ToSortedCidSet(),
-		Height:            types.Uint64(1),
-		ParentWeightNum:   types.Uint64(10),
-		ParentWeightDenom: types.Uint64(1),
-		StateRoot:         baseTS.ToSlice()[0].StateRoot,
+		Parents:      baseTS.ToSortedCidSet(),
+		Height:       types.Uint64(1),
+		ParentWeight: types.Uint64(10000),
+		StateRoot:    baseTS.ToSlice()[0].StateRoot,
 	}
 
 	// Wait for network connection notifications to propagate
@@ -91,25 +90,22 @@ func TestChainSync(t *testing.T) {
 	baseTS := nodes[0].ChainReader.Head()
 	stateRoot := baseTS.ToSlice()[0].StateRoot
 	nextBlk1 := &types.Block{
-		Parents:           baseTS.ToSortedCidSet(),
-		Height:            types.Uint64(1),
-		ParentWeightNum:   types.Uint64(10),
-		ParentWeightDenom: types.Uint64(1),
-		StateRoot:         stateRoot,
+		Parents:      baseTS.ToSortedCidSet(),
+		Height:       types.Uint64(1),
+		ParentWeight: types.Uint64(10000),
+		StateRoot:    stateRoot,
 	}
 	nextBlk2 := &types.Block{
-		Parents:           types.NewSortedCidSet(nextBlk1.Cid()),
-		Height:            types.Uint64(2),
-		ParentWeightNum:   types.Uint64(20),
-		ParentWeightDenom: types.Uint64(1),
-		StateRoot:         stateRoot,
+		Parents:      types.NewSortedCidSet(nextBlk1.Cid()),
+		Height:       types.Uint64(2),
+		ParentWeight: types.Uint64(20000),
+		StateRoot:    stateRoot,
 	}
 	nextBlk3 := &types.Block{
-		Parents:           types.NewSortedCidSet(nextBlk2.Cid()),
-		Height:            types.Uint64(3),
-		ParentWeightNum:   types.Uint64(30),
-		ParentWeightDenom: types.Uint64(1),
-		StateRoot:         stateRoot,
+		Parents:      types.NewSortedCidSet(nextBlk2.Cid()),
+		Height:       types.Uint64(3),
+		ParentWeight: types.Uint64(30000),
+		StateRoot:    stateRoot,
 	}
 
 	assert.NoError(nodes[0].AddNewBlock(ctx, nextBlk1))

--- a/node/node.go
+++ b/node/node.go
@@ -653,10 +653,10 @@ func (node *Node) StartMining(ctx context.Context) error {
 		getState := func(ctx context.Context, ts consensus.TipSet) (state.Tree, error) {
 			return getStateFromKey(ctx, ts.String())
 		}
-		getWeight := func(ctx context.Context, ts consensus.TipSet) (uint64, uint64, error) {
+		getWeight := func(ctx context.Context, ts consensus.TipSet) (uint64, error) {
 			parent, err := ts.Parents()
 			if err != nil {
-				return uint64(0), uint64(0), err
+				return uint64(0), err
 			}
 			// TODO handle genesis cid more gracefully
 			if parent.Len() == 0 {
@@ -664,7 +664,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 			}
 			pSt, err := getStateFromKey(ctx, parent.String())
 			if err != nil {
-				return uint64(0), uint64(0), err
+				return uint64(0), err
 			}
 			return node.Consensus.Weight(ctx, ts, pSt)
 		}

--- a/node/testing.go
+++ b/node/testing.go
@@ -363,10 +363,10 @@ func RunCreateMiner(t *testing.T, node *Node, from address.Address, pledge uint6
 	getStateTree := func(ctx context.Context, ts consensus.TipSet) (state.Tree, error) {
 		return getStateFromKey(ctx, ts.String())
 	}
-	getWeight := func(ctx context.Context, ts consensus.TipSet) (uint64, uint64, error) {
+	getWeight := func(ctx context.Context, ts consensus.TipSet) (uint64, error) {
 		parent, err := ts.Parents()
 		if err != nil {
-			return uint64(0), uint64(0), err
+			return uint64(0), err
 		}
 		// TODO handle genesis cid more gracefully
 		if parent.Len() == 0 {
@@ -374,7 +374,7 @@ func RunCreateMiner(t *testing.T, node *Node, from address.Address, pledge uint6
 		}
 		pSt, err := getStateFromKey(ctx, parent.String())
 		if err != nil {
-			return uint64(0), uint64(0), err
+			return uint64(0), err
 		}
 		return node.Consensus.Weight(ctx, ts, pSt)
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -31,11 +31,8 @@ type Block struct {
 	// holders for an epoch.
 	Parents SortedCidSet `json:"parents"`
 
-	// ParentWeightNum is the numerator of the aggregate chain weight of the parent set.
-	ParentWeightNum Uint64 `json:"parentWeightNumerator"`
-
-	// ParentWeightDenom is the denominator of the aggregate chain weight of the parent set
-	ParentWeightDenom Uint64 `json:"parentWeightDenominator"`
+	// ParentWeight is the aggregate chain weight of the parent set.
+	ParentWeight Uint64 `json:"parentWeight"`
 
 	// Height is the chain height of this block.
 	Height Uint64 `json:"height"`

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -90,22 +90,21 @@ func TestTriangleEncoding(t *testing.T) {
 		// pass when non-zero values do not due to nil/null encoding.
 
 		b := &Block{
-			Miner:             newAddress(),
-			Ticket:            Bytes([]byte{0x01, 0x02, 0x03}),
-			Height:            Uint64(2),
-			Nonce:             3,
-			Messages:          []*SignedMessage{newSignedMessage()},
-			MessageReceipts:   []*MessageReceipt{{ExitCode: 1}},
-			Parents:           NewSortedCidSet(SomeCid()),
-			ParentWeightNum:   Uint64(1),
-			ParentWeightDenom: Uint64(1),
-			Proof:             NewTestPoSt(),
-			StateRoot:         SomeCid(),
+			Miner:           newAddress(),
+			Ticket:          Bytes([]byte{0x01, 0x02, 0x03}),
+			Height:          Uint64(2),
+			Nonce:           3,
+			Messages:        []*SignedMessage{newSignedMessage()},
+			MessageReceipts: []*MessageReceipt{{ExitCode: 1}},
+			Parents:         NewSortedCidSet(SomeCid()),
+			ParentWeight:    Uint64(1000),
+			Proof:           NewTestPoSt(),
+			StateRoot:       SomeCid(),
 		}
 		s := reflect.TypeOf(*b)
 		// This check is here to request that you add a non-zero value for new fields
 		// to the above (and update the field count below).
-		require.Equal(t, 11, s.NumField())
+		require.Equal(t, 10, s.NumField())
 		testRoundTrip(t, b)
 	})
 }

--- a/types/fixed_point.go
+++ b/types/fixed_point.go
@@ -1,0 +1,78 @@
+package types
+
+// The fixed point type is an alias for uint64.  The type has two functions,
+// one for converting from uint64 to a *big.Float and another for converting
+// from a *big.Float to a uint64.  The decimal point is fixed 3 decimal digits
+// from the least significant digit of the underlying uint64.  Ex:
+//
+// fixed point value: 1244590
+// floating point value: 124.590
+//
+// The max integral number this implementation supports is 2^54 -1.
+// This is chosen because ceil(log2(1000)) == 10, so we take 10 binary digits to
+// encode the fractional part which leaves 54 bits for the integral part.
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+)
+
+// MaxFixedPointIntegralNum is the largest whole number that can be encoded
+// as a fixed point.
+const MaxFixedPointIntegralNum = 18014398509481983 // (2^54 - 1)
+
+// BigToFixed takes in a big Float and returns a uint64 encoded fixed point.
+func BigToFixed(f *big.Float) (uint64, error) {
+	// check that f is not too big.
+	if cmp := f.Cmp(big.NewFloat(float64(MaxFixedPointIntegralNum))); cmp == 1 {
+		return uint64(0), errors.New("float too big to store in fixed point")
+	}
+
+	s := fmt.Sprintf("%.3f", f)
+	parts := strings.Split(s, ".")
+	integral, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return uint64(0), err
+	}
+	fractional, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return uint64(0), err
+	}
+
+	fixed := integral * 1000
+	fixed += fractional
+	return fixed, nil
+}
+
+// FixedToBig takes in a uint64 encoded fixed point and returns a big Float.
+func FixedToBig(fixed uint64) (*big.Float, error) {
+	if fixed > uint64((MaxFixedPointIntegralNum+1)*1000) {
+		return nil, errors.New("uint64 does not validly encode fixed point")
+	}
+	q := int64(fixed / 1000)
+	m := int64(fixed % 1000)
+
+	integral := big.NewFloat(0.0).SetInt64(q)
+	integral.SetPrec(64)
+	fractional := big.NewFloat(0.0).SetInt64(m)
+
+	divF := big.NewFloat(1000.0)
+	fractional.Quo(fractional, divF)
+
+	integral.Add(integral, fractional)
+	return integral, nil
+}
+
+// FixedStr returns a printable string with the correct decimal place for the
+// input uint64 encoded fixed point number.
+func FixedStr(fixed uint64) (string, error) {
+	b, err := FixedToBig(fixed)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%.3f", b), nil
+}

--- a/types/fixed_point_test.go
+++ b/types/fixed_point_test.go
@@ -1,0 +1,94 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func MustBigToFixed(b *big.Float, a *assert.Assertions) uint64 {
+	ret, err := BigToFixed(b)
+	a.NoError(err)
+	return ret
+}
+
+func MustFixedToBig(f uint64, a *assert.Assertions) *big.Float {
+	ret, err := FixedToBig(f)
+	a.NoError(err)
+	return ret
+}
+
+func TestBigToFixed(t *testing.T) {
+	assert := assert.New(t)
+	t.Run("truncate decimal", func(t *testing.T) {
+		x := 30004828.209239083240324
+		bigX := big.NewFloat(x)
+		assert.Equal(uint64(30004828209), MustBigToFixed(bigX, assert))
+	})
+
+	t.Run("upper limit", func(t *testing.T) {
+		y := "18014398509481983.555"
+		bigY := new(big.Float)
+		bigY.Parse(y, 10)
+		assert.Equal(uint64(18014398509481983555), MustBigToFixed(bigY, assert))
+	})
+
+	t.Run("handle high precision decimal", func(t *testing.T) {
+		z := 300.0000000000000000000000000000001
+		bigZ := big.NewFloat(z)
+		assert.Equal(uint64(300000), MustBigToFixed(bigZ, assert))
+	})
+
+	t.Run("no truncation", func(t *testing.T) {
+		w := 4000001.530
+		bigW := big.NewFloat(w)
+		assert.Equal(uint64(4000001530), MustBigToFixed(bigW, assert))
+	})
+}
+
+func TestFixedToBig(t *testing.T) {
+	assert := assert.New(t)
+	t.Run("whole number", func(t *testing.T) {
+		x := uint64(81053000)
+		expectedBigX := big.NewFloat(81053.0)
+		// Use strings to forget about precison + rounding error
+		expectedBigXStr := fmt.Sprintf("%.3f", expectedBigX)
+		assert.Equal(expectedBigXStr, fmt.Sprintf("%.3f", MustFixedToBig(x, assert)))
+	})
+
+	t.Run("fractional part and whole number", func(t *testing.T) {
+		y := uint64(75123499)
+		expectedBigY := big.NewFloat(75123.499)
+		expectedBigYStr := fmt.Sprintf("%.3f", expectedBigY)
+		assert.Equal(expectedBigYStr, fmt.Sprintf("%.3f", MustFixedToBig(y, assert)))
+	})
+}
+
+func TestFixedRoundTrip(t *testing.T) {
+	assert := assert.New(t)
+	w := 4000001.530
+	bigW := big.NewFloat(w)
+	expectedWStr := fmt.Sprintf("%.3f", bigW)
+	assert.Equal(expectedWStr, fmt.Sprintf("%.3f", MustFixedToBig(MustBigToFixed(bigW, assert), assert)))
+}
+
+func TestOversized(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("Oversized *big.Float", func(t *testing.T) {
+		a := "18014398509481986.555"
+		bigA := new(big.Float)
+		bigA.Parse(a, 10)
+		_, err := BigToFixed(bigA)
+		assert.Error(err)
+	})
+
+	// Oversized uint64
+	t.Run("Oversized uint64", func(t *testing.T) {
+		b := uint64(18014398509481986555)
+		_, err := FixedToBig(b)
+		assert.Error(err)
+	})
+}


### PR DESCRIPTION
TODO 
- [x] Touch up fixed point -- use type alias, check for values that are too big in both conv functions and test that check
- [x] Update block structure and mining and consensus logic to use fixed point repr
- [x] Fix go-filecoin tests to move to this weight repr.

As part of the acceptance criteria here is a quick analysis that the weight field won't overflow:   
- The fixed point representation can handle numbers less than 2^54 - 1.  
- On expectation (and with pretty tight bounds as lots of rounds pass) we have 1 block per round.  Each block adds 10 + 100 * power.  power is < 1/2, so new weight per round is bounded by 60 (on expectation).  Number of rounds before overflow = x1 > (2^54 - 1) / 60.   
- In the extreme case there are 5 rounds per minute (probably only 2), number of minutes before overflow > x2 = (2^54 -1) / 300
- 60 minutes in an hour, 24 hours in a day, 365 days in a year, number of years before overflow > x3 = (2^54 -1) / (300 * 60 * 24 * 365) ~= 10^8 or about 100 million years.

So not only is this overflow threshold good enough for the medium term, it is good enough for mainnet!  If we want some bits back from the header we can also spare some here.

Note that for this PR we are assuming that 3 decimal points of accuracy is enough for consensus guarantees (will need to revisit with protocol working group).  Adding a test of overflow as I originally suggested doesn't seem to add much value so I'm omitting that unless someone wants it.