### PR TITLE
limiting some log spam from libp2p services 🦇

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,16 @@ func main() {
 
 	logging.SetAllLoggers(oldlogging.Level(n))
 
+	logging.SetLogLevel("dht", "error")          // nolint: errcheck
+	logging.SetLogLevel("bitswap", "error")      // nolint: errcheck
+	logging.SetLogLevel("heartbeat", "error")    // nolint: errcheck
+	logging.SetLogLevel("blockservice", "error") // nolint: errcheck
+	logging.SetLogLevel("peerqueue", "error")    // nolint: errcheck
+	logging.SetLogLevel("swarm", "error")        // nolint: errcheck
+	logging.SetLogLevel("swarm2", "error")       // nolint: errcheck
+	logging.SetLogLevel("basichost", "error")    // nolint: errcheck
+	logging.SetLogLevel("dht_net", "error")      // nolint: errcheck
+
 	// TODO implement help text like so:
 	// https://github.com/ipfs/go-ipfs/blob/master/core/commands/root.go#L91
 	// TODO don't panic if run without a command.


### PR DESCRIPTION
fix https://github.com/filecoin-project/go-filecoin-infra/issues/94
an alternative solution is described here: https://github.com/ipfs/go-log/issues/54