### PR TITLE
Extend circleci no_output_timeout for main build of build_docker_img workflow 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,7 @@ jobs:
           name: build an image of all binaries
           command: |
             docker build -t filecoin:all --target=builder .
+          no_output_timeout: 20m
 
       - run:
           name: build & push image - filecoin


### PR DESCRIPTION
Installing deps has increased its runtime and has been timing out, increasing the time from the default 10m to 20m.