### PR TITLE
Filecoin nodes use libp2p autorelay

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -42,8 +42,14 @@ const (
 	// AutoSealIntervalSeconds configures the daemon to check for and seal any staged sectors on an interval.
 	AutoSealIntervalSeconds = "auto-seal-interval-seconds"
 
-	// SwarmListen is the multiaddr for this Filecoin node
-	SwarmListen = "swarmlisten"
+	// SwarmAddress is the multiaddr for this Filecoin node
+	SwarmAddress = "swarmlisten"
+
+	// SwarmPublicRelayAddress is a public address that the filecoin node
+	// will listen on if it is operating as a relay.  We use this to specify
+	// the public ip:port of a relay node that is sitting behind a static
+	// NAT mapping.
+	SwarmPublicRelayAddress = "swarmrelaypublic"
 
 	// BlockTime is the duration string of the block time the daemon will
 	// run with.  TODO: this should eventually be more explicitly grouped
@@ -67,6 +73,10 @@ const (
 
 	// ClusterNightly populates config bootstrap addrs with the dns multiaddrs of the nightly cluster and other nightly cluster specific bootstrap parameters
 	ClusterNightly = "cluster-nightly"
+
+	// IsRelay when set causes the the daemon to provide libp2p relay
+	// services allowing other filecoin nodes behind NATs to talk directly.
+	IsRelay = "is-relay"
 )
 
 // command object for the local cli

--- a/commands/ping_daemon_test.go
+++ b/commands/ping_daemon_test.go
@@ -16,7 +16,7 @@ func TestPing2Nodes(t *testing.T) {
 	defer d2.ShutdownSuccess()
 
 	t.Log("[failure] not connected")
-	d1.RunFail("failed to dial",
+	d1.RunFail("failed to find any peer in table",
 		"ping", "--count=2", d2.GetID(),
 	)
 

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,8 @@ func newDefaultDatastoreConfig() *DatastoreConfig {
 
 // SwarmConfig holds all configuration options related to the swarm.
 type SwarmConfig struct {
-	Address string `json:"address"`
+	Address            string `json:"address"`
+	PublicRelayAddress string `json:"public_relay_address,omitempty"`
 }
 
 func newDefaultSwarmConfig() *SwarmConfig {

--- a/node/config.go
+++ b/node/config.go
@@ -15,9 +15,10 @@ func OptionsFromRepo(r repo.Repo) ([]ConfigOpt, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	cfg := r.Config()
 	cfgopts := []ConfigOpt{
-		// Libp2pOptions can only be called once, so add all options here
+		// Libp2pOptions can only be called once, so add all options here.
 		Libp2pOptions(
 			libp2p.ListenAddrStrings(cfg.Swarm.Address),
 			libp2p.Identity(sk),

--- a/package.json
+++ b/package.json
@@ -176,6 +176,24 @@
       "hash": "QmYPZzd9VqmJDwxUnThfeSbV1Y5o53aVPDijTB7j7rS9Ep",
       "name": "go-blockservice",
       "version": "1.1.20"
+    },
+    {
+      "author": "vyzo",
+      "hash": "QmXmZtMdQokSodDNvPdhDyaVRAjgybvR8dQtuMsNoWv4Lq",
+      "name": "go-libp2p-autonat",
+      "version": "1.0.5"
+    },
+    {
+      "author": "vyzo",
+      "hash": "QmWuMW6UKZMJo9bFFDwnjg8tW3AtKisMHHrXEutQdmJ19N",
+      "name": "go-libp2p-circuit",
+      "version": "2.3.8"
+    },
+    {
+      "author": "vyzo",
+      "hash": "QmRmMbeY5QC5iMsuW16wchtFt8wmYTv2suWb8t9MV8dsxm",
+      "name": "go-libp2p-autonat-svc",
+      "version": "1.0.5"
     }
   ],
   "gxVersion": "0.12.1",

--- a/tools/iptb-plugins/filecoin/local/localfilecoin.go
+++ b/tools/iptb-plugins/filecoin/local/localfilecoin.go
@@ -133,10 +133,6 @@ func (l *Localfilecoin) Init(ctx context.Context, args ...string) (testbedi.Outp
 
 	lcfg := icfg.(*config.Config)
 
-	if err := lcfg.Set("bootstrap.addresses", "[]"); err != nil {
-		return nil, err
-	}
-
 	if err := lcfg.Set("api.address", `"/ip4/127.0.0.1/tcp/0"`); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1209

- [x] by default nodes check if publically dialable against bootstrappers and initialize host with relay if not
- [x] daemon flag for initializing node as a relay provider, includes providing autoNAT service 
- [x] manual verification that this is working properly.  Includes setting up a DO droplet running new bootstrapper providing relay services.
- [x] double check if relays can be behind NATs.  If not work with infra to figure out a bootstrapper deployment strategy that works.  Ideas here: 1. remove bootstrappers from behind NAT and have them run relays 2. add in a config option to specify separate relays and deploy these free from NATs separately from bootstrappers in the cluster 