### PR TITLE
Gas Rewards groundwork

### DIFF
--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -107,7 +107,7 @@ func NewMockActor(list exec.Exports) *MockActor {
 
 func makeCtx(method string) exec.VMContext {
 	addrGetter := address.NewForTestGetter()
-	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, types.NewBlockHeight(0))
+	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 }
 
 func TestMakeTypedExportSuccess(t *testing.T) {

--- a/actor/builtin/paymentbroker/paymentbroker_test.go
+++ b/actor/builtin/paymentbroker/paymentbroker_test.go
@@ -55,7 +55,7 @@ func TestPaymentBrokerCreateChannel(t *testing.T) {
 	pdata := core.MustConvertParams(target, big.NewInt(10))
 	msg := types.NewMessage(payer, address.PaymentBrokerAddress, 0, types.NewAttoFILFromFIL(1000), "createChannel", pdata)
 
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(err)
 	require.NoError(result.ExecutionError)
 
@@ -73,27 +73,6 @@ func TestPaymentBrokerCreateChannel(t *testing.T) {
 	assert.Equal(types.NewAttoFILFromFIL(0), channel.AmountRedeemed)
 	assert.Equal(target, channel.Target)
 	assert.Equal(types.NewBlockHeight(10), channel.Eol)
-}
-
-func TestPaymentBrokerCreateChannelFromNonAccountActorIsAnError(t *testing.T) {
-	require := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	payee := address.NewForTestGetter()()
-	_, st, vms := requireGenesis(ctx, t, payee)
-
-	// Create a non-account actor
-	payerActor := actor.NewActor(types.NewCidForTestGetter()(), types.NewAttoFILFromFIL(2000))
-	payer := address.NewForTestGetter()()
-	state.MustSetActor(st, payer, payerActor)
-
-	pdata := core.MustConvertParams(payee, big.NewInt(10))
-	msg := types.NewMessage(payer, address.PaymentBrokerAddress, 0, types.NewAttoFILFromFIL(1000), "createChannel", pdata)
-	_, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
-
-	// expect error
-	require.Error(err)
 }
 
 func TestPaymentBrokerUpdate(t *testing.T) {
@@ -496,7 +475,7 @@ func TestNewPaymentBrokerVoucher(t *testing.T) {
 func establishChannel(ctx context.Context, st state.Tree, vms vm.StorageMap, from address.Address, target address.Address, nonce uint64, amt *types.AttoFIL, eol *types.BlockHeight) *types.ChannelID {
 	pdata := core.MustConvertParams(target, eol)
 	msg := types.NewMessage(from, address.PaymentBrokerAddress, nonce, amt, "createChannel", pdata)
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	if err != nil {
 		panic(err)
 	}
@@ -640,7 +619,7 @@ func (sys *system) applySignatureMessage(target address.Address, amtInt uint64, 
 }
 
 func (sys *system) ApplyMessage(msg *types.Message, height uint64) (*consensus.ApplicationResult, error) {
-	return consensus.ApplyMessage(sys.ctx, sys.st, sys.vms, msg, types.NewBlockHeight(height))
+	return th.ApplyTestMessage(sys.st, sys.vms, msg, types.NewBlockHeight(height))
 }
 
 func requireGetPaymentChannel(t *testing.T, ctx context.Context, st state.Tree, vms vm.StorageMap, payer address.Address, channelId *types.ChannelID) *PaymentChannel {

--- a/actor/builtin/storagemarket/storagemarket_test.go
+++ b/actor/builtin/storagemarket/storagemarket_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	. "github.com/filecoin-project/go-filecoin/actor/builtin/storagemarket"
 	"github.com/filecoin-project/go-filecoin/address"
-	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/core"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -31,7 +30,7 @@ func TestStorageMarketCreateMiner(t *testing.T) {
 	pid := th.RequireRandomPeerID()
 	pdata := actor.MustConvertParams(big.NewInt(10), []byte{}, pid)
 	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(100), "createMiner", pdata)
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(err)
 	require.Nil(result.ExecutionError)
 
@@ -64,7 +63,7 @@ func TestStorageMarketCreateMinerPledgeTooLow(t *testing.T) {
 	st, vms := core.CreateStorages(ctx, t)
 	pdata := actor.MustConvertParams(pledge, []byte{}, th.RequireRandomPeerID())
 	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, MinimumCollateral(pledge), "createMiner", pdata)
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 
 	assert.NoError(err)
 	require.NotNil(result.ExecutionError)
@@ -80,7 +79,7 @@ func TestStorageMarketCreateMinerInsufficientCollateral(t *testing.T) {
 	st, vms := core.CreateStorages(ctx, t)
 	pdata := actor.MustConvertParams(big.NewInt(15000), []byte{}, th.RequireRandomPeerID())
 	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(14), "createMiner", pdata)
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 
 	assert.NoError(err)
 	require.NotNil(result.ExecutionError)
@@ -100,13 +99,13 @@ func TestStorageMarkeCreateMinerDoesNotOverwriteActorBalance(t *testing.T) {
 	require.NoError(err)
 
 	msg := types.NewMessage(address.TestAddress2, minerAddr, 0, types.NewAttoFILFromFIL(100), "", []byte{})
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(err)
 	require.Equal(uint8(0), result.Receipt.ExitCode)
 
 	pdata := actor.MustConvertParams(big.NewInt(15), []byte{}, th.RequireRandomPeerID())
 	msg = types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createMiner", pdata)
-	result, err = consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err = th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(err)
 	require.Equal(uint8(0), result.Receipt.ExitCode)
 	require.NoError(result.ExecutionError)
@@ -135,7 +134,7 @@ func TestStorageMarkeCreateMinerErrorsOnInvalidKey(t *testing.T) {
 	pdata := actor.MustConvertParams(big.NewInt(15), publicKey, th.RequireRandomPeerID())
 
 	msg := types.NewMessage(address.TestAddress, address.StorageMarketAddress, 0, types.NewAttoFILFromFIL(200), "createMiner", pdata)
-	result, err := consensus.ApplyMessage(ctx, st, vms, msg, types.NewBlockHeight(0))
+	result, err := th.ApplyTestMessage(st, vms, msg, types.NewBlockHeight(0))
 	require.NoError(err)
 	assert.Contains(result.ExecutionError.Error(), miner.Errors[miner.ErrPublicKeyTooBig].Error())
 }

--- a/api/impl/actor_test.go
+++ b/api/impl/actor_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -56,7 +57,7 @@ func TestActorLs(t *testing.T) {
 		genBlock, err := consensus.InitGenesis(nd.CborStore(), nd.Blockstore)
 		require.NoError(err)
 		b1 := types.NewBlockForTest(genBlock, 1)
-		ts := consensus.RequireNewTipSet(require, b1)
+		ts := testhelpers.RequireNewTipSet(require, b1)
 		chainStore, ok := nd.ChainReader.(chain.Store)
 		require.True(ok)
 
@@ -65,7 +66,7 @@ func TestActorLs(t *testing.T) {
 			TipSetStateRoot: genBlock.StateRoot,
 		})
 		require.NoError(err)
-		err = chainStore.SetHead(ctx, consensus.RequireNewTipSet(require, b1))
+		err = chainStore.SetHead(ctx, testhelpers.RequireNewTipSet(require, b1))
 		require.NoError(err)
 
 		assert.NoError(nd.Start(ctx))

--- a/api/impl/chain_test.go
+++ b/api/impl/chain_test.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"encoding/json"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/chain"
@@ -40,7 +41,7 @@ func TestChainHead(t *testing.T) {
 		chainStore, ok := n.ChainReader.(chain.Store)
 		require.True(ok)
 
-		chainStore.SetHead(ctx, consensus.RequireNewTipSet(require, blk))
+		chainStore.SetHead(ctx, testhelpers.RequireNewTipSet(require, blk))
 
 		api := New(n)
 		out, err := api.Chain().Head()
@@ -64,9 +65,9 @@ func TestChainHead(t *testing.T) {
 		chainStore, ok := n.ChainReader.(chain.Store)
 		require.True(ok)
 
-		newTipSet := consensus.RequireNewTipSet(require, blk)
-		consensus.RequireTipSetAdd(require, blk2, newTipSet)
-		consensus.RequireTipSetAdd(require, blk3, newTipSet)
+		newTipSet := testhelpers.RequireNewTipSet(require, blk)
+		testhelpers.RequireTipSetAdd(require, blk2, newTipSet)
+		testhelpers.RequireTipSetAdd(require, blk3, newTipSet)
 
 		someErr := chainStore.SetHead(ctx, newTipSet)
 		require.NoError(someErr)
@@ -98,7 +99,7 @@ func TestChainLsRun(t *testing.T) {
 		require.NoError(err)
 
 		chlBlock := types.NewBlockForTest(genBlock, 1)
-		chlTS := consensus.RequireNewTipSet(require, chlBlock)
+		chlTS := testhelpers.RequireNewTipSet(require, chlBlock)
 		err = chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
 			TipSet:          chlTS,
 			TipSetStateRoot: chlBlock.StateRoot,
@@ -136,7 +137,7 @@ func TestChainLsRun(t *testing.T) {
 
 		chainStore, ok := n.ChainReader.(chain.Store)
 		require.True(ok)
-		chlTS := consensus.RequireNewTipSet(require, chlBlock)
+		chlTS := testhelpers.RequireNewTipSet(require, chlBlock)
 		err := chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
 			TipSet:          chlTS,
 			TipSetStateRoot: chlBlock.StateRoot,

--- a/api/impl/mining.go
+++ b/api/impl/mining.go
@@ -2,7 +2,6 @@ package impl
 
 import (
 	"context"
-
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/mining"
@@ -55,7 +54,7 @@ func (api *nodeMining) Once(ctx context.Context) (*types.Block, error) {
 		return nd.Consensus.Weight(ctx, ts, pSt)
 	}
 
-	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, consensus.ApplyMessages, nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, blockTime)
+	worker := mining.NewDefaultWorker(nd.MsgPool, getState, getWeight, consensus.NewDefaultProcessor(), nd.PowerTable, nd.Blockstore, nd.CborStore(), miningAddr, blockTime)
 
 	res, err := mining.MineOnce(ctx, worker, mineDelay, ts)
 	if err != nil {

--- a/api2/impl/msgapi/waiter.go
+++ b/api2/impl/msgapi/waiter.go
@@ -158,7 +158,7 @@ func (w *Waiter) receiptFromTipSet(ctx context.Context, msgCid cid.Cid, ts conse
 	if err != nil {
 		return nil, err
 	}
-	res, err := consensus.ProcessTipSet(ctx, ts, st, vm.NewStorageMap(w.bs))
+	res, err := consensus.NewDefaultProcessor().ProcessTipSet(ctx, st, vm.NewStorageMap(w.bs), ts)
 	if err != nil {
 		return nil, err
 	}

--- a/api2/impl/msgapi/waiter_test.go
+++ b/api2/impl/msgapi/waiter_test.go
@@ -2,11 +2,12 @@ package msgapi
 
 import (
 	"context"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"sync"
 	"testing"
 	"time"
 
-	hamt "gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
+	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
 	bstore "gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
 	"gx/ipfs/QmYZwey1thDTynSrvd6qQkX24UpTka6TFhQ2v569UpoqxD/go-ipfs-exchange-offline"
 	bserv "gx/ipfs/QmZ9PMwfBmywNgpxG7zRHKsAno76gMCBbKGBTVXbma44H7/go-blockservice"
@@ -174,7 +175,7 @@ func TestWaitConflicting(t *testing.T) {
 	b2.Ticket = []byte{1}
 	core.MustPut(cst, b2)
 
-	ts := consensus.RequireNewTipSet(require, b1, b2)
+	ts := testhelpers.RequireNewTipSet(require, b1, b2)
 	chain.RequirePutTsas(ctx, require, chainStore, &chain.TipSetAndState{
 		TipSet:          ts,
 		TipSetStateRoot: baseBlock.StateRoot,

--- a/chain/power_table_view_test.go
+++ b/chain/power_table_view_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"context"
 	"github.com/filecoin-project/go-filecoin/proofs"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"testing"
 
 	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
@@ -71,12 +72,13 @@ func requireMinerWithPower(ctx context.Context, t *testing.T, power uint64) (bst
 	chain := NewDefaultStore(chainDS, cst, calcGenBlk.Cid())
 
 	// chain.Syncer
+	processor := testhelpers.NewTestProcessor()
 	prover := proofs.NewFakeProver(true, nil)
-	con := consensus.NewExpected(cst, bs, &consensus.TestView{}, calcGenBlk.Cid(), prover)
+	con := consensus.NewExpected(cst, bs, processor, &testhelpers.TestView{}, calcGenBlk.Cid(), prover)
 	syncer := NewDefaultSyncer(cst, cst, con, chain) // note we use same cst for on and offline for tests
 
 	// Initialize stores to contain genesis block and state
-	calcGenTS := consensus.RequireNewTipSet(require, calcGenBlk)
+	calcGenTS := testhelpers.RequireNewTipSet(require, calcGenBlk)
 	genTsas := &TipSetAndState{
 		TipSet:          calcGenTS,
 		TipSetStateRoot: calcGenBlk.StateRoot,

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -284,32 +284,6 @@ func TestMinerCreate(t *testing.T) {
 		d1.MineAndPropagate(time.Second, d)
 		wg.Wait()
 	})
-
-	t.Run("insufficient funds", func(t *testing.T) {
-		t.Parallel()
-		d1 := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0]), th.KeyFile(fixtures.KeyFilePaths()[2])).Start()
-		defer d1.ShutdownSuccess()
-
-		d := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[2])).Start()
-		defer d.ShutdownSuccess()
-
-		d1.ConnectSuccess(d)
-
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			d.RunFail("not enough balance",
-				"miner", "create",
-				"--from", testAddr.String(), "--price", "0", "--limit", "0", "10", "10000000000000000",
-			)
-			wg.Done()
-		}()
-
-		// ensure mining runs after the command in our goroutine
-		d1.MineAndPropagate(time.Second, d)
-		wg.Wait()
-	})
 }
 
 func TestMinerAddAskSuccess(t *testing.T) {

--- a/consensus/genesis.go
+++ b/consensus/genesis.go
@@ -2,12 +2,6 @@ package consensus
 
 import (
 	"context"
-
-	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
-	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
-	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
-
-	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/account"
@@ -17,6 +11,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
+	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
+	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
 )
 
 // GenesisInitFunc is the signature for function that is used to create a genesis block.
@@ -168,20 +164,4 @@ func SetupDefaultActors(ctx context.Context, st state.Tree, storageMap vm.Storag
 	pbAct.Balance = types.NewAttoFILFromFIL(0)
 
 	return st.SetActor(ctx, address.PaymentBrokerAddress, pbAct)
-}
-
-// ApplyMessageDirect applies a given message directly to the given state tree and storage map.
-func ApplyMessageDirect(ctx context.Context, st state.Tree, storageMap vm.StorageMap, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) (*ApplicationResult, error) {
-	encodedParams, err := abi.ToEncodedValues(params...)
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid params")
-	}
-
-	fromActor, err := st.GetActor(ctx, from)
-	if err != nil {
-		return nil, errors.Wrap(err, "invalid from actor")
-	}
-
-	message := types.NewMessage(from, to, uint64(fromActor.Nonce), value, method, encodedParams)
-	return ApplyMessage(ctx, st, storageMap, message, types.NewBlockHeight(0))
 }

--- a/consensus/tipset_test.go
+++ b/consensus/tipset_test.go
@@ -1,12 +1,14 @@
-package consensus
+package consensus_test
 
 import (
 	"sort"
 	"testing"
 
-	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	. "github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,7 +100,7 @@ func RequireTestBlocks(t *testing.T) (*types.Block, *types.Block, *types.Block) 
 func RequireTestTipSet(t *testing.T) TipSet {
 	require := require.New(t)
 	b1, b2, b3 := RequireTestBlocks(t)
-	return RequireNewTipSet(require, b1, b2, b3)
+	return testhelpers.RequireNewTipSet(require, b1, b2, b3)
 }
 
 func TestTipSetAddBlock(t *testing.T) {
@@ -108,18 +110,18 @@ func TestTipSetAddBlock(t *testing.T) {
 
 	// Add Valid
 	ts1 := TipSet{}
-	RequireTipSetAdd(require, b1, ts1)
+	testhelpers.RequireTipSetAdd(require, b1, ts1)
 	assert.Equal(1, len(ts1))
-	RequireTipSetAdd(require, b2, ts1)
-	RequireTipSetAdd(require, b3, ts1)
+	testhelpers.RequireTipSetAdd(require, b2, ts1)
+	testhelpers.RequireTipSetAdd(require, b3, ts1)
 
-	ts2 := RequireNewTipSet(require, b1, b2, b3)
+	ts2 := testhelpers.RequireNewTipSet(require, b1, b2, b3)
 	assert.Equal(ts2, ts1)
 
 	// Invalid height
 	b2.Height = 5
 	ts := TipSet{}
-	RequireTipSetAdd(require, b1, ts)
+	testhelpers.RequireTipSetAdd(require, b1, ts)
 	err := ts.AddBlock(b2)
 	assert.Error(err)
 	b2.Height = b1.Height
@@ -127,7 +129,7 @@ func TestTipSetAddBlock(t *testing.T) {
 	// Invalid parent set
 	b2.Parents = types.NewSortedCidSet(cid1, cid2)
 	ts = TipSet{}
-	RequireTipSetAdd(require, b1, ts)
+	testhelpers.RequireTipSetAdd(require, b1, ts)
 	err = ts.AddBlock(b2)
 	assert.Error(err)
 	b2.Parents = b1.Parents
@@ -135,7 +137,7 @@ func TestTipSetAddBlock(t *testing.T) {
 	// Invalid weight
 	b2.ParentWeight = types.Uint64(3000)
 	ts = TipSet{}
-	RequireTipSetAdd(require, b1, ts)
+	testhelpers.RequireTipSetAdd(require, b1, ts)
 	err = ts.AddBlock(b2)
 	assert.Error(err)
 }
@@ -253,7 +255,7 @@ func TestTipSetEquals(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	ts2 := RequireNewTipSet(require, b1, b2)
+	ts2 := testhelpers.RequireNewTipSet(require, b1, b2)
 	assert.True(!ts2.Equals(ts))
 	ts2.AddBlock(b3)
 	assert.True(ts.Equals(ts2))

--- a/core/message_pool.go
+++ b/core/message_pool.go
@@ -5,17 +5,13 @@ import (
 	"sort"
 	"sync"
 
-	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	hamt "gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
-	errors "gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
-	logging "gx/ipfs/QmcuXC5cxs79ro2cUuHs4HQ2bkDLJUYokwL8aivcX6HW3C/go-log"
-
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/types"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 )
-
-var log = logging.Logger("core")
 
 // MessagePool keeps an unordered, de-duplicated set of Messages and supports removal by CID.
 // By 'de-duplicated' we mean that insertion of a message by cid that already
@@ -109,15 +105,7 @@ func collectChainsMessagesToHeight(ctx context.Context, store *hamt.CborIpldStor
 	}
 	for h > height {
 		for _, blk := range curTipSet {
-			blkmsgs := blk.Messages
-			if len(blkmsgs) > 0 {
-				if blkmsgs[0].From != address.NetworkAddress {
-					log.Error("invalid tipset: missing reward message")
-				} else {
-					blkmsgs = blkmsgs[1:]
-				}
-			}
-			msgs = append(msgs, blkmsgs...)
+			msgs = append(msgs, blk.Messages...)
 		}
 		parents, err := curTipSet.Parents()
 		if err != nil {
@@ -185,18 +173,7 @@ func UpdateMessagePool(ctx context.Context, pool *MessagePool, store *hamt.CborI
 		for _, blk := range old {
 			// skip genesis block
 			if blk.Height > 0 {
-				blkmsgs := blk.Messages
-
-				// If the block height is not empty, and there is no reward message, something went really wrong
-				if len(blkmsgs) > 0 {
-					if blkmsgs[0].From != address.NetworkAddress {
-						log.Error("invalid tipset: missing reward message")
-					} else {
-						blkmsgs = blkmsgs[1:]
-					}
-				}
-
-				addToPool = append(addToPool, blkmsgs...)
+				addToPool = append(addToPool, blk.Messages...)
 			}
 		}
 		for _, blk := range new {

--- a/mining/scheduler_test.go
+++ b/mining/scheduler_test.go
@@ -80,7 +80,7 @@ func TestSchedulerUpdatesNullBlkCount(t *testing.T) {
 	assert, require, ts := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	blk2 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
-	ts2 := consensus.RequireNewTipSet(require, blk2)
+	ts2 := th.RequireNewTipSet(require, blk2)
 
 	checkNullBlocks := 0
 	checkNullBlockMine := func(c context.Context, inTS consensus.TipSet, nBC int, outCh chan<- Output) bool {
@@ -121,9 +121,9 @@ func TestSchedulerPassesManyValues(t *testing.T) {
 	var checkTS consensus.TipSet
 	// make tipsets with progressively higher heights
 	blk2 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
-	ts2 := consensus.RequireNewTipSet(require, blk2)
+	ts2 := th.RequireNewTipSet(require, blk2)
 	blk3 := &types.Block{StateRoot: types.SomeCid(), Height: 2}
-	ts3 := consensus.RequireNewTipSet(require, blk3)
+	ts3 := th.RequireNewTipSet(require, blk3)
 	var head consensus.TipSet
 	headFunc := func() consensus.TipSet {
 		return head
@@ -157,9 +157,9 @@ func TestSchedulerCollect(t *testing.T) {
 	assert, require, ts1 := newTestUtils(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	blk2 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
-	ts2 := consensus.RequireNewTipSet(require, blk2)
+	ts2 := th.RequireNewTipSet(require, blk2)
 	blk3 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
-	ts3 := consensus.RequireNewTipSet(require, blk3)
+	ts3 := th.RequireNewTipSet(require, blk3)
 	var head consensus.TipSet
 	headFunc := func() consensus.TipSet {
 		return head
@@ -250,9 +250,9 @@ func TestSchedulerMultiRoundWithCollect(t *testing.T) {
 	}
 	// make tipsets with progressively higher heights
 	blk2 := &types.Block{StateRoot: types.SomeCid(), Height: 1}
-	ts2 := consensus.RequireNewTipSet(require, blk2)
+	ts2 := th.RequireNewTipSet(require, blk2)
 	blk3 := &types.Block{StateRoot: types.SomeCid(), Height: 2}
-	ts3 := consensus.RequireNewTipSet(require, blk3)
+	ts3 := th.RequireNewTipSet(require, blk3)
 
 	checkValsMine := func(c context.Context, inTS consensus.TipSet, nBC int, outCh chan<- Output) bool {
 		assert.Equal(inTS, checkTS)

--- a/node/block.go
+++ b/node/block.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmVRxA4J3UPQpw74dLrQ6NJkfysCA1H4GU28gVpXQt9zMU/go-libp2p-pubsub"
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"

--- a/node/message.go
+++ b/node/message.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-
 	"gx/ipfs/QmVRxA4J3UPQpw74dLrQ6NJkfysCA1H4GU28gVpXQt9zMU/go-libp2p-pubsub"
 
 	"github.com/filecoin-project/go-filecoin/types"

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -150,7 +150,7 @@ func TestNodeStartMining(t *testing.T) {
 	ctx := context.Background()
 
 	seed := MakeChainSeed(t, TestGenCfg)
-	minerNode := MakeNodeWithChainSeed(t, seed, PeerKeyOpt(PeerKeys[0]), AutoSealIntervalSecondsOpt(1))
+	minerNode := MakeNodeWithChainSeed(t, seed, []ConfigOpt{}, PeerKeyOpt(PeerKeys[0]), AutoSealIntervalSecondsOpt(1))
 
 	// TODO we need a principled way to construct an API that can be used both by node and by
 	// tests. It should enable selective replacement of dependencies.

--- a/protocol/hello/hello_test.go
+++ b/protocol/hello/hello_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
-	peer "gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
-	mocknet "gx/ipfs/QmYxivS34F2M2n44WQQnRHGAKS8aoRUxwGpi9wk4Cdn4Jf/go-libp2p/p2p/net/mock"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
+	"gx/ipfs/QmYxivS34F2M2n44WQQnRHGAKS8aoRUxwGpi9wk4Cdn4Jf/go-libp2p/p2p/net/mock"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -15,7 +15,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/consensus"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
-	types "github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 type mockSyncCallback struct {
@@ -49,8 +49,8 @@ func TestHelloHandshake(t *testing.T) {
 
 	genesisA := &types.Block{Nonce: 451}
 
-	heavy1 := consensus.RequireNewTipSet(require, &types.Block{Nonce: 1000, Height: 2})
-	heavy2 := consensus.RequireNewTipSet(require, &types.Block{Nonce: 1001, Height: 3})
+	heavy1 := th.RequireNewTipSet(require, &types.Block{Nonce: 1000, Height: 2})
+	heavy2 := th.RequireNewTipSet(require, &types.Block{Nonce: 1001, Height: 3})
 
 	msc1, msc2 := new(mockSyncCallback), new(mockSyncCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
@@ -104,8 +104,8 @@ func TestHelloBadGenesis(t *testing.T) {
 	genesisA := &types.Block{Nonce: 451}
 	genesisB := &types.Block{Nonce: 101}
 
-	heavy1 := consensus.RequireNewTipSet(require, &types.Block{Nonce: 1000, Height: 2})
-	heavy2 := consensus.RequireNewTipSet(require, &types.Block{Nonce: 1001, Height: 3})
+	heavy1 := th.RequireNewTipSet(require, &types.Block{Nonce: 1000, Height: 2})
+	heavy2 := th.RequireNewTipSet(require, &types.Block{Nonce: 1001, Height: 3})
 
 	msc1, msc2 := new(mockSyncCallback), new(mockSyncCallback)
 	hg1, hg2 := &mockHeaviestGetter{heavy1}, &mockHeaviestGetter{heavy2}
@@ -140,12 +140,12 @@ func TestHelloMultiBlock(t *testing.T) {
 
 	genesisA := &types.Block{Nonce: 452}
 
-	heavy1 := consensus.RequireNewTipSet(require,
+	heavy1 := th.RequireNewTipSet(require,
 		&types.Block{Nonce: 1000, Height: 2},
 		&types.Block{Nonce: 1002, Height: 2},
 		&types.Block{Nonce: 1004, Height: 2},
 	)
-	heavy2 := consensus.RequireNewTipSet(require,
+	heavy2 := th.RequireNewTipSet(require,
 		&types.Block{Nonce: 1001, Height: 3},
 		&types.Block{Nonce: 1003, Height: 3},
 		&types.Block{Nonce: 1005, Height: 3},

--- a/protocol/retrieval/retrieval_protocol_test.go
+++ b/protocol/retrieval/retrieval_protocol_test.go
@@ -197,8 +197,8 @@ func configureMinerAndClient(t *testing.T) (minerNode *node.Node, clientNode *no
 	seed := node.MakeChainSeed(t, node.TestGenCfg)
 
 	// make two nodes, one of which is the minerNode (and gets the miner peer key)
-	minerNode = node.MakeNodeWithChainSeed(t, seed, node.PeerKeyOpt(node.PeerKeys[0]), node.AutoSealIntervalSecondsOpt(0))
-	clientNode = node.MakeNodeWithChainSeed(t, seed)
+	minerNode = node.MakeNodeWithChainSeed(t, seed, []node.ConfigOpt{}, node.PeerKeyOpt(node.PeerKeys[0]), node.AutoSealIntervalSecondsOpt(0))
+	clientNode = node.MakeNodeWithChainSeed(t, seed, []node.ConfigOpt{})
 
 	// give the minerNode node a key and the miner associated with that key
 	seed.GiveKey(t, minerNode, 0)

--- a/protocol/storage/storage_protocol_test.go
+++ b/protocol/storage/storage_protocol_test.go
@@ -50,8 +50,8 @@ func TestStorageProtocolBasic(t *testing.T) {
 	seed := node.MakeChainSeed(t, node.TestGenCfg)
 
 	// make two nodes, one of which is the miner (and gets the miner peer key)
-	minerNode := node.MakeNodeWithChainSeed(t, seed, node.PeerKeyOpt(node.PeerKeys[0]), node.AutoSealIntervalSecondsOpt(1))
-	clientNode := node.MakeNodeWithChainSeed(t, seed)
+	minerNode := node.MakeNodeWithChainSeed(t, seed, []node.ConfigOpt{}, node.PeerKeyOpt(node.PeerKeys[0]), node.AutoSealIntervalSecondsOpt(1))
+	clientNode := node.MakeNodeWithChainSeed(t, seed, []node.ConfigOpt{})
 	minerAPI := impl.New(minerNode)
 
 	// TODO we need a principled way to construct an API that can be used both by node and by

--- a/state/cached_tree.go
+++ b/state/cached_tree.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/actor"

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -2,13 +2,12 @@ package testhelpers
 
 import (
 	"context"
-	"math/big"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
 	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
 	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
 	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
+	"math/big"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -20,8 +20,6 @@ var (
 	ErrMessageSigned = errors.New("message already contains a signature")
 	// ErrMessageUnsigned is returned when `RecoverAddress` is called on a signedmessage that does not contain a signature
 	ErrMessageUnsigned = errors.New("message does not contain a signature")
-	// ErrInvalidSignature indicates an invalid message signature.
-	ErrInvalidSignature = errors.New("invalid signature by sender over message data")
 )
 
 func init() {

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -45,7 +45,7 @@ func TestVMContextStorage(t *testing.T) {
 
 	to, err := cstate.GetActor(ctx, toAddr)
 	assert.NoError(err)
-	vmCtx := NewVMContext(nil, to, msg, cstate, vms, types.NewBlockHeight(0))
+	vmCtx := NewVMContext(nil, to, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 
 	node, err := cbor.WrapObject([]byte("hello"), types.DefaultHashFunction, -1)
 	assert.NoError(err)
@@ -57,7 +57,7 @@ func TestVMContextStorage(t *testing.T) {
 	toActorBack, err := st.GetActor(ctx, toAddr)
 	assert.NoError(err)
 
-	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, types.NewBlockHeight(0)).ReadStorage()
+	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0)).ReadStorage()
 	assert.NoError(err)
 	assert.Equal(storage, node.RawData())
 }
@@ -88,7 +88,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -114,7 +114,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -145,7 +145,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, msg, tree, vms, types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(to, "foo", nil, []interface{}{})
@@ -176,7 +176,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -212,7 +212,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -228,7 +228,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, types.NewBlockHeight(0))
+		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		addr, err := vmctx.AddressForNewActor()
 
 		require.NoError(err)
@@ -259,10 +259,10 @@ func TestVMContextIsAccountActor(t *testing.T) {
 
 	accountActor, err := account.NewActor(types.NewAttoFILFromFIL(1000))
 	require.NoError(err)
-	ctx := NewVMContext(accountActor, nil, nil, nil, vms, nil)
+	ctx := NewVMContext(accountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasCost(0), nil)
 	assert.True(ctx.IsFromAccountActor())
 
 	nonAccountActor := actor.NewActor(types.NewCidForTestGetter()(), types.NewAttoFILFromFIL(1000))
-	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, nil)
+	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasCost(0), nil)
 	assert.False(ctx.IsFromAccountActor())
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -5,7 +5,6 @@ package vm
 
 import (
 	"context"
-
 	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
 
 	"github.com/filecoin-project/go-filecoin/actor"
@@ -17,7 +16,7 @@ import (
 // will always satisfy either ShouldRevert() or IsFault().
 func Send(ctx context.Context, vmCtx *Context) ([][]byte, uint8, error) {
 	deps := sendDeps{
-		transfer: transfer,
+		transfer: Transfer,
 	}
 
 	return send(ctx, deps, vmCtx)
@@ -65,7 +64,8 @@ func send(ctx context.Context, deps sendDeps, vmCtx *Context) ([][]byte, uint8, 
 	return nil, code, err
 }
 
-func transfer(fromActor, toActor *actor.Actor, value *types.AttoFIL) error {
+// Transfer transfers the given value between two actors.
+func Transfer(fromActor, toActor *actor.Actor, value *types.AttoFIL) error {
 	if value.IsNegative() {
 		return errors.Errors[errors.ErrCannotTransferNegativeValue]
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -26,11 +26,11 @@ func TestTransfer(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		assert := assert.New(t)
 
-		assert.NoError(transfer(actor1, actor2, types.NewAttoFILFromFIL(10)))
+		assert.NoError(Transfer(actor1, actor2, types.NewAttoFILFromFIL(10)))
 		assert.Equal(actor1.Balance, types.NewAttoFILFromFIL(90))
 		assert.Equal(actor2.Balance, types.NewAttoFILFromFIL(60))
 
-		assert.NoError(transfer(actor1, actor3, types.NewAttoFILFromFIL(20)))
+		assert.NoError(Transfer(actor1, actor3, types.NewAttoFILFromFIL(20)))
 		assert.Equal(actor1.Balance, types.NewAttoFILFromFIL(70))
 		assert.Equal(actor3.Balance, types.NewAttoFILFromFIL(20))
 	})
@@ -39,8 +39,8 @@ func TestTransfer(t *testing.T) {
 		assert := assert.New(t)
 
 		negval := types.NewAttoFILFromFIL(0).Sub(types.NewAttoFILFromFIL(1000))
-		assert.EqualError(transfer(actor2, actor3, types.NewAttoFILFromFIL(1000)), "not enough balance")
-		assert.EqualError(transfer(actor2, actor3, negval), "cannot transfer negative values")
+		assert.EqualError(Transfer(actor2, actor3, types.NewAttoFILFromFIL(1000)), "not enough balance")
+		assert.EqualError(Transfer(actor2, actor3, negval), "cannot transfer negative values")
 	})
 }
 
@@ -67,7 +67,7 @@ func TestSendErrorHandling(t *testing.T) {
 		}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -84,7 +84,7 @@ func TestSendErrorHandling(t *testing.T) {
 		deps := sendDeps{}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -106,7 +106,7 @@ func TestSendErrorHandling(t *testing.T) {
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{
 			actor2.Code: &actor.FakeActor{},
 		}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)


### PR DESCRIPTION
# Problem

We are not currently charging message senders for processing their messages. This PR is a step towards that, but in the process it became clear that significant changes to processor were needed before the real work can begin. This PR really contains 3 changes:

## 1. Validate that message senders have sufficient funds to cover gas costs.

This is a necessary step toward charging gas. To reduce the change of DOS attacks, incoming messages from accounts that have insufficient funds to cover gas costs should be given as little processing time as possible. Consequently, we ensure that the sender's funds minus the message's value exceed the maximum possible gas charge (`GasPrice*GasLimit`) prior to any additional processing.

## 2. Transfer block reward directly as part of message processing rather than by applying a mining message.

The reasoning behind this move is outlined in #1540. In short, reward messages were requiring more and more special case logic (including logic to avoid gas payments), and the benefits decrease as we add gas payments.

## 3. Refactor Processor functions into mockable structs.

closes #1554

Message processing is central to most processes in the app. We have been putting a lot of effort into making messages valid in testing, and this was about to get worse with gas processing. The refactor allows us to write unit tests that focus on the important processes without having to worry about valid messages (signatures, nonces, gas) and allow us to create valid blocks without tracking all the mining rewards (important in consensus tests). The refactor follows the patter of the node refactor, but happens at a lower level.
