### PR TITLE
Rename GasCost to GasUnits

### DIFF
--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -107,7 +107,7 @@ func NewMockActor(list exec.Exports) *MockActor {
 
 func makeCtx(method string) exec.VMContext {
 	addrGetter := address.NewForTestGetter()
-	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 }
 
 func TestMakeTypedExportSuccess(t *testing.T) {

--- a/api/impl/miner.go
+++ b/api/impl/miner.go
@@ -22,7 +22,7 @@ func newNodeMiner(api *nodeAPI, plumbingAPI *plumbing.API) *nodeMiner {
 	return &nodeMiner{api: api, plumbingAPI: plumbingAPI}
 }
 
-func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error) {
+func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error) {
 	nd := nm.api.node
 
 	if err := setDefaultFromAddr(&fromAddr, nd); err != nil {
@@ -41,7 +41,7 @@ func (nm *nodeMiner) Create(ctx context.Context, fromAddr address.Address, gasPr
 	return *res, nil
 }
 
-func (nm *nodeMiner) UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, newPid peer.ID) (cid.Cid, error) {
+func (nm *nodeMiner) UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, newPid peer.ID) (cid.Cid, error) {
 	return nm.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
@@ -54,7 +54,7 @@ func (nm *nodeMiner) UpdatePeerID(ctx context.Context, fromAddr, minerAddr addre
 	)
 }
 
-func (nm *nodeMiner) AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error) {
+func (nm *nodeMiner) AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error) {
 	return nm.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,

--- a/api/impl/paych.go
+++ b/api/impl/paych.go
@@ -21,7 +21,7 @@ func newNodePaych(api *nodeAPI, plumbingAPI *plumbing.API) *nodePaych {
 	return &nodePaych{api: api, plumbingAPI: plumbingAPI}
 }
 
-func (np *nodePaych) Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
+func (np *nodePaych) Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
 	return np.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
@@ -102,7 +102,7 @@ func (np *nodePaych) Voucher(ctx context.Context, fromAddr address.Address, chan
 	return multibase.Encode(multibase.Base58BTC, cborVoucher)
 }
 
-func (np *nodePaych) Redeem(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error) {
+func (np *nodePaych) Redeem(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, voucherRaw string) (cid.Cid, error) {
 	voucher, err := decodeVoucher(voucherRaw)
 	if err != nil {
 		return cid.Undef, err
@@ -120,7 +120,7 @@ func (np *nodePaych) Redeem(ctx context.Context, fromAddr address.Address, gasPr
 	)
 }
 
-func (np *nodePaych) Reclaim(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID) (cid.Cid, error) {
+func (np *nodePaych) Reclaim(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, channel *types.ChannelID) (cid.Cid, error) {
 	return np.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,
@@ -133,7 +133,7 @@ func (np *nodePaych) Reclaim(ctx context.Context, fromAddr address.Address, gasP
 	)
 }
 
-func (np *nodePaych) Close(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error) {
+func (np *nodePaych) Close(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, voucherRaw string) (cid.Cid, error) {
 	voucher, err := decodeVoucher(voucherRaw)
 	if err != nil {
 		return cid.Undef, err
@@ -151,7 +151,7 @@ func (np *nodePaych) Close(ctx context.Context, fromAddr address.Address, gasPri
 	)
 }
 
-func (np *nodePaych) Extend(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
+func (np *nodePaych) Extend(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error) {
 	return np.plumbingAPI.MessageSend(
 		ctx,
 		fromAddr,

--- a/api/miner.go
+++ b/api/miner.go
@@ -13,9 +13,9 @@ import (
 
 // Miner is the interface that defines methods to manage miner operations.
 type Miner interface {
-	Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error)
-	UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, newPid peer.ID) (cid.Cid, error)
-	AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error)
+	Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, pledge uint64, pid peer.ID, collateral *types.AttoFIL) (address.Address, error)
+	UpdatePeerID(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, newPid peer.ID) (cid.Cid, error)
+	AddAsk(ctx context.Context, fromAddr, minerAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price *types.AttoFIL, expiry *big.Int) (cid.Cid, error)
 	GetOwner(ctx context.Context, minerAddr address.Address) (address.Address, error)
 	GetPledge(ctx context.Context, minerAddr address.Address) (*big.Int, error)
 	GetPower(ctx context.Context, minerAddr address.Address) (*big.Int, error)

--- a/api/paych.go
+++ b/api/paych.go
@@ -12,11 +12,11 @@ import (
 
 // Paych is the interface that defines methods to execute payment channel operations.
 type Paych interface {
-	Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
+	Create(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, target address.Address, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
 	Ls(ctx context.Context, fromAddr address.Address, payerAddr address.Address) (map[string]*paymentbroker.PaymentChannel, error)
 	Voucher(ctx context.Context, fromAddr address.Address, channel *types.ChannelID, amount *types.AttoFIL) (string, error)
-	Redeem(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error)
-	Reclaim(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID) (cid.Cid, error)
-	Close(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, voucherRaw string) (cid.Cid, error)
-	Extend(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
+	Redeem(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, voucherRaw string) (cid.Cid, error)
+	Reclaim(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, channel *types.ChannelID) (cid.Cid, error)
+	Close(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, voucherRaw string) (cid.Cid, error)
+	Extend(ctx context.Context, fromAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, channel *types.ChannelID, eol *types.BlockHeight, amount *types.AttoFIL) (cid.Cid, error)
 }

--- a/commands/main.go
+++ b/commands/main.go
@@ -299,27 +299,27 @@ func isConnectionRefused(err error) bool {
 	return syscallErr.Err == syscall.ECONNREFUSED
 }
 
-var priceOption = cmdkit.StringOption("price", "Price (FIL e.g. 0.00013) to pay for each GasUnit consumed mining this message")
+var priceOption = cmdkit.StringOption("price", "Price (FIL e.g. 0.00013) to pay for each GasUnits consumed mining this message")
 var limitOption = cmdkit.Int64Option("limit", "Maximum number of GasUnits this message is allowed to consume")
 
-func parseGasOptions(req *cmds.Request) (gasPrice types.AttoFIL, gasCost types.GasCost, error error) {
+func parseGasOptions(req *cmds.Request) (gasPrice types.AttoFIL, gasCost types.GasUnits, error error) {
 	priceOption := req.Options["price"]
 	if priceOption == nil {
-		return types.AttoFIL{}, types.NewGasCost(0), errors.New("price option is required")
+		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("price option is required")
 	}
 
 	price, ok := types.NewAttoFILFromFILString(priceOption.(string))
 	if !ok {
-		return types.AttoFIL{}, types.NewGasCost(0), errors.New("invalid gas price (specify FIL as a decimal number)")
+		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("invalid gas price (specify FIL as a decimal number)")
 	}
 
 	gasLimitInt, ok := req.Options["limit"].(int64)
 	if !ok {
-		return types.AttoFIL{}, types.NewGasCost(0), errors.New("invalid gas limit")
+		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("invalid gas limit")
 	}
 	if gasLimitInt < 0 {
-		return types.AttoFIL{}, types.NewGasCost(0), errors.New("gas limit cannot be less than zero")
+		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("gas limit cannot be less than zero")
 	}
 
-	return *price, types.NewGasCost(gasLimitInt), nil
+	return *price, types.NewGasUnits(gasLimitInt), nil
 }

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -337,7 +337,7 @@ func CallQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to a
 		Params: params,
 	}
 
-	vmCtx := vm.NewVMContext(nil, toActor, msg, cachedSt, vms, types.NewGasPrice(0), types.NewGasCost(0), optBh)
+	vmCtx := vm.NewVMContext(nil, toActor, msg, cachedSt, vms, types.NewGasPrice(0), types.NewGasUnits(0), optBh)
 	ret, retCode, err := vm.Send(ctx, vmCtx)
 
 	return ret, retCode, err

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -62,7 +62,7 @@ func TestProcessBlockSuccess(t *testing.T) {
 
 	vms := th.VMStorage()
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	blk := &types.Block{
@@ -117,7 +117,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	})
 
 	msg1 := types.NewMessage(fromAddr1, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	blk1 := &types.Block{
 		Height:    20,
@@ -127,7 +127,7 @@ func TestProcessTipSetSuccess(t *testing.T) {
 	}
 
 	msg2 := types.NewMessage(fromAddr2, toAddr, 0, types.NewAttoFILFromFIL(50), "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	blk2 := &types.Block{
 		Height:    20,
@@ -181,7 +181,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 	})
 
 	msg1 := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(501), "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	blk1 := &types.Block{
 		Height:    20,
@@ -192,7 +192,7 @@ func TestProcessTipsConflicts(t *testing.T) {
 	}
 
 	msg2 := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(502), "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	blk2 := &types.Block{
 		Height:    20,
@@ -242,7 +242,7 @@ func TestProcessBlockBadMsgSig(t *testing.T) {
 
 	vms := th.VMStorage()
 	msg := types.NewMessage(fromAddr, toAddr, 0, types.NewAttoFILFromFIL(550), "", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	// corrupt the message data
 	smsg.Message.Nonce = 13
@@ -327,7 +327,7 @@ func TestProcessBlockVMErrors(t *testing.T) {
 		toAddr:                 act2,
 	})
 	msg := types.NewMessage(fromAddr, toAddr, 0, nil, "returnRevertError", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	blk := &types.Block{
 		Height:    20,
@@ -435,7 +435,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 			addr2: act2,
 		})
 		msg := types.NewMessage(addr1, addr2, 5, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 		require.NoError(err)
 
 		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, types.NewBlockHeight(0))
@@ -463,7 +463,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 			addr2: act2,
 		})
 		msg := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 		require.NoError(err)
 
 		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, types.NewBlockHeight(0))
@@ -477,7 +477,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 
 		addr1, _, addr2, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasCost(50))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
@@ -499,7 +499,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.NoError(err)
 
 		msg := types.NewMessage(addr1, addr2, 0, types.ZeroAttoFIL, "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasCost(50))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(err)
 
 		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, types.NewBlockHeight(0))
@@ -513,7 +513,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 
 		addr1, _, _, _, st, mockSigner := mustSetup2Actors(t, types.NewAttoFILFromFIL(1000), types.NewAttoFILFromFIL(10000))
 		msg := types.NewMessage(addr1, addr1, 0, types.NewAttoFILFromFIL(550), "", []byte{})
-		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasCost(0))
+		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(0))
 		require.NoError(err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
@@ -640,14 +640,14 @@ func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
 
 	// send 500 from addr1 to addr2
 	msg := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(500), "", []byte{})
-	smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, types.NewBlockHeight(0))
 	require.NoError(err)
 
 	// send 250 along from addr2 to addr3
 	msg = types.NewMessage(addr2, addr3, 0, types.NewAttoFILFromFIL(300), "", []byte{})
-	smsg, err = types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err = types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, types.NewBlockHeight(0))
 	require.NoError(err)

--- a/consensus/tipset_test.go
+++ b/consensus/tipset_test.go
@@ -32,7 +32,7 @@ func block(require *require.Assertions, height int, parentCid cid.Cid, parentWei
 	addrGetter := address.NewForTestGetter()
 
 	m1 := types.NewMessage(mockSignerForTest.Addresses[0], addrGetter(), 0, types.NewAttoFILFromFIL(10), "hello", []byte(msg))
-	sm1, err := types.NewSignedMessage(*m1, &mockSignerForTest, types.NewGasPrice(0), types.NewGasCost(0))
+	sm1, err := types.NewSignedMessage(*m1, &mockSignerForTest, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	ret := []byte{1, 2}
 

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -313,7 +313,7 @@ func GenGenesisCar(cfg *GenesisCfg, out io.Writer, seed int64) (*RenderedGenInfo
 func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) ([]types.Bytes, error) {
 	pdata := actor.MustConvertParams(params...)
 	msg := types.NewMessage(from, to, 0, value, method, pdata)
-	smsg, err := types.NewSignedMessage(*msg, &signer{}, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, &signer{}, types.NewGasPrice(0), types.NewGasUnits(0))
 	if err != nil {
 		return nil, err
 	}

--- a/mining/worker_test.go
+++ b/mining/worker_test.go
@@ -143,21 +143,21 @@ func TestApplyMessagesForSuccessTempAndPermFailures(t *testing.T) {
 	// exercise the categorization.
 	// addr2 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addr2, addr1, 0, nil, "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	// This is actually okay and should result in a receipt
 	msg2 := types.NewMessage(addr1, addr2, 0, nil, "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	// The following two are sending to self -- errSelfSend, a permanent error.
 	msg3 := types.NewMessage(addr1, addr1, 1, nil, "", nil)
-	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	msg4 := types.NewMessage(addr2, addr2, 1, nil, "", nil)
-	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	messages := []*types.SignedMessage{smsg1, smsg2, smsg3, smsg4}
@@ -228,21 +228,21 @@ func TestGeneratePoolBlockResults(t *testing.T) {
 
 	// addr3 doesn't correspond to an extant account, so this will trigger errAccountNotFound -- a temporary failure.
 	msg1 := types.NewMessage(addrs[2], addrs[0], 0, nil, "", nil)
-	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg1, err := types.NewSignedMessage(*msg1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	// This is actually okay and should result in a receipt
 	msg2 := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
-	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg2, err := types.NewSignedMessage(*msg2, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	// The following two are sending to self -- errSelfSend, a permanent error.
 	msg3 := types.NewMessage(addrs[0], addrs[0], 1, nil, "", nil)
-	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg3, err := types.NewSignedMessage(*msg3, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	msg4 := types.NewMessage(addrs[1], addrs[1], 0, nil, "", nil)
-	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg4, err := types.NewSignedMessage(*msg4, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	pool.Add(smsg1)
@@ -347,7 +347,7 @@ func TestGenerateError(t *testing.T) {
 
 	// This is actually okay and should result in a receipt
 	msg := types.NewMessage(addrs[0], addrs[1], 0, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 	pool.Add(smsg)
 

--- a/node/message_propagate_test.go
+++ b/node/message_propagate_test.go
@@ -35,7 +35,7 @@ func TestMessagePropagation(t *testing.T) {
 	require.NoError(err)
 
 	gasPrice := types.NewGasPrice(0)
-	gasLimit := types.NewGasCost(0)
+	gasLimit := types.NewGasUnits(0)
 	_, err = nodes[0].PlumbingAPI.MessageSend(ctx, nd0Addr, address.NetworkAddress, types.NewAttoFILFromFIL(123), gasPrice, gasLimit, "")
 	require.NoError(err)
 

--- a/node/node.go
+++ b/node/node.go
@@ -732,7 +732,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 
 					// TODO: determine these algorithmically by simulating call and querying historical prices
 					gasPrice := types.NewGasPrice(0)
-					gasCost := types.NewGasCost(0)
+					gasCost := types.NewGasUnits(0)
 
 					val := result.SealingResult
 					// This call can fail due to, e.g. nonce collisions, so we retry to make sure we include it,
@@ -914,7 +914,7 @@ func (node *Node) CallQueryMethod(ctx context.Context, to address.Address, metho
 // CreateMiner creates a new miner actor for the given account and returns its address.
 // It will wait for the the actor to appear on-chain and add set the address to mining.minerAddress in the config.
 // TODO: This should live in a MinerAPI or some such. It's here until we have a proper API layer.
-func (node *Node) CreateMiner(ctx context.Context, accountAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasCost, pledge uint64, pid libp2ppeer.ID, collateral *types.AttoFIL) (_ *address.Address, err error) {
+func (node *Node) CreateMiner(ctx context.Context, accountAddr address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, pledge uint64, pid libp2ppeer.ID, collateral *types.AttoFIL) (_ *address.Address, err error) {
 	// Only create a miner if we don't already have one.
 	if _, err := node.MiningAddress(); err != ErrNoMinerAddress {
 		return nil, fmt.Errorf("can only have one miner per node")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -386,7 +386,7 @@ func TestSendMessage(t *testing.T) {
 		assert.NoError(node.Start(ctx))
 
 		gasPrice := types.NewGasPrice(0)
-		gasLimit := types.NewGasCost(0)
+		gasLimit := types.NewGasUnits(0)
 		_, err = node.PlumbingAPI.MessageSend(ctx, nodeAddr, nodeAddr, types.NewZeroAttoFIL(), gasPrice, gasLimit, "foo", []byte{})
 		require.NoError(err)
 

--- a/node/testing.go
+++ b/node/testing.go
@@ -257,7 +257,7 @@ func RunCreateMiner(t *testing.T, node *Node, from address.Address, pledge uint6
 	require.NoError(err)
 
 	go func() {
-		minerAddr, err := node.CreateMiner(ctx, from, types.NewGasPrice(0), types.NewGasCost(0), pledge, pid, &collateral)
+		minerAddr, err := node.CreateMiner(ctx, from, types.NewGasPrice(0), types.NewGasUnits(0), pledge, pid, &collateral)
 		resultChan <- MustCreateMinerResult{MinerAddress: minerAddr, Err: err}
 		wg.Done()
 	}()

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -44,7 +44,7 @@ func (api *API) ActorGetSignature(ctx context.Context, actorAddr address.Address
 // message using the wallet. This call "sends" in the sense that it enqueues the
 // message in the msg pool and broadcasts it to the network; it does not wait for the
 // message to go on chain.
-func (api *API) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error) {
+func (api *API) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	return api.msgSender.Send(ctx, from, to, value, gasPrice, gasLimit, method, params...)
 }
 

--- a/plumbing/msg/sender.go
+++ b/plumbing/msg/sender.go
@@ -49,7 +49,7 @@ func NewSender(repo repo.Repo, wallet *wallet.Wallet, chainReader chain.ReadStor
 }
 
 // Send sends a message. See api description.
-func (s *Sender) Send(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error) {
+func (s *Sender) Send(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	// If the from address isn't set attempt to use the default address.
 	if from == (address.Address{}) {
 		ret, err := GetAndMaybeSetDefaultSenderAddress(s.repo, s.wallet)

--- a/plumbing/msg/sender_test.go
+++ b/plumbing/msg/sender_test.go
@@ -60,7 +60,7 @@ func TestSend(t *testing.T) {
 
 		s := NewSender(repo, w, chainStore, msgPool, publish)
 		require.Equal(0, len(msgPool.Pending()))
-		_, err = s.Send(context.Background(), addr, addr, types.NewAttoFILFromFIL(uint64(2)), types.NewGasPrice(0), types.NewGasCost(0), "")
+		_, err = s.Send(context.Background(), addr, addr, types.NewAttoFILFromFIL(uint64(2)), types.NewGasPrice(0), types.NewGasUnits(0), "")
 		require.NoError(err)
 		assert.Equal(1, len(msgPool.Pending()))
 		assert.True(publishCalled)
@@ -81,7 +81,7 @@ func TestSend(t *testing.T) {
 		addTwentyMessages := func(batch int) {
 			defer wg.Done()
 			for i := 0; i < 20; i++ {
-				_, err := s.Send(ctx, addr, addr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasCost(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
+				_, err := s.Send(ctx, addr, addr, types.NewZeroAttoFIL(), types.NewGasPrice(0), types.NewGasUnits(0), fmt.Sprintf("%d-%d", batch, i), []byte{})
 				require.NoError(err)
 			}
 		}
@@ -134,7 +134,7 @@ func TestNextNonce(t *testing.T) {
 
 		msg := types.NewMessage(addr, addr, 0, nil, "foo", []byte{})
 		msg.Nonce = 42
-		smsg, err := types.NewSignedMessage(*msg, w, types.NewGasPrice(0), types.NewGasCost(0))
+		smsg, err := types.NewSignedMessage(*msg, w, types.NewGasPrice(0), types.NewGasUnits(0))
 		assert.NoError(err)
 		core.MustAdd(msgPool, smsg)
 

--- a/plumbing/msg/waiter_test.go
+++ b/plumbing/msg/waiter_test.go
@@ -147,11 +147,11 @@ func TestWaitConflicting(t *testing.T) {
 
 	// Create conflicting messages
 	m1 := types.NewMessage(addr1, addr3, 0, types.NewAttoFILFromFIL(6000), "", nil)
-	sm1, err := types.NewSignedMessage(*m1, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	sm1, err := types.NewSignedMessage(*m1, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	m2 := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(6000), "", nil)
-	sm2, err := types.NewSignedMessage(*m2, &mockSigner, types.NewGasPrice(0), types.NewGasCost(0))
+	sm2, err := types.NewSignedMessage(*m2, &mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	baseTS := chainStore.Head()

--- a/porcelain/message.go
+++ b/porcelain/message.go
@@ -16,7 +16,7 @@ import (
 
 // mswrPlumbing is the subset of the plumbing.API that MessageSendWithRetry uses.
 type mswrPlumbing interface {
-	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 }
 
@@ -38,7 +38,7 @@ var log = logging.Logger("porcelain") // nolint: deadcode
 //
 // Access to failures might make this a little better but really the solution is
 // to not have re-tries, eg if we had nonce lanes.
-func MessageSendWithRetry(ctx context.Context, plumbing mswrPlumbing, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasCost, params ...interface{}) (err error) {
+func MessageSendWithRetry(ctx context.Context, plumbing mswrPlumbing, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) (err error) {
 	for i := 0; i < int(numRetries); i++ {
 		log.Debugf("SendMessageAndWait (%s) retry %d/%d, waitDuration %v", method, i, numRetries, waitDuration)
 

--- a/porcelain/message_test.go
+++ b/porcelain/message_test.go
@@ -24,13 +24,13 @@ type fakePlumbing struct {
 	msgCid  cid.Cid
 	sendCnt int
 
-	messageSend func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error)
+	messageSend func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	messageWait func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 }
 
 // Satisfy the plumbing API:
 
-func (fp *fakePlumbing) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error) {
+func (fp *fakePlumbing) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	return fp.messageSend(ctx, from, to, value, gasPrice, gasLimit, method, params...)
 }
 
@@ -39,7 +39,7 @@ func (fp *fakePlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func
 }
 
 // Fake implementations we'll use.
-func (fp *fakePlumbing) successfulMessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error) {
+func (fp *fakePlumbing) successfulMessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
 	fp.msgCid = newCid()
 	fp.sendCnt++
 	return fp.msgCid, nil
@@ -60,7 +60,7 @@ func (fp *fakePlumbing) unsuccessfulMessageWait(ctx context.Context, msgCid cid.
 
 func TestMessageSendWithRetry(t *testing.T) {
 	t.Parallel()
-	val, gasPrice, gasLimit := types.NewAttoFILFromFIL(0), types.NewGasPrice(0), types.NewGasCost(0)
+	val, gasPrice, gasLimit := types.NewAttoFILFromFIL(0), types.NewGasPrice(0), types.NewGasUnits(0)
 
 	t.Run("succeeds on first try", func(t *testing.T) {
 		require := require.New(t)

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -68,7 +68,7 @@ type storageDealState struct {
 
 // plumbing is the subset of the plumbing API that storage.Miner needs.
 type plumbing interface {
-	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasCost, method string, params ...interface{}) (cid.Cid, error)
+	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 	ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error)
 }
@@ -535,7 +535,7 @@ func (sm *Miner) submitPoSt(start, end *types.BlockHeight, inputs []generatePost
 
 	// TODO: algorithmically determine appropriate values for these
 	gasPrice := types.NewGasPrice(submitPostGasPrice)
-	gasLimit := types.NewGasCost(submitPostGasLimit)
+	gasLimit := types.NewGasUnits(submitPostGasLimit)
 
 	err = porcelain.MessageSendWithRetry(ctx, sm.plumbingAPI, 10 /*retries*/, sm.node.GetBlockTime() /*wait time*/, sm.minerOwnerAddr, sm.minerAddr, types.NewAttoFIL(big.NewInt(0)), "submitPoSt", gasPrice, gasLimit, proof[:])
 	if err != nil {

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -141,7 +141,7 @@ func (ms testSigner) SignBytes(data []byte, addr address.Address) (types.Signatu
 
 // ApplyTestMessage sends a message directly to the vm, bypassing message validation
 func ApplyTestMessage(st state.Tree, store vm.StorageMap, msg *types.Message, bh *types.BlockHeight) (*consensus.ApplicationResult, error) {
-	smsg, err := types.NewSignedMessage(*msg, testSigner{}, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, testSigner{}, types.NewGasPrice(0), types.NewGasUnits(0))
 	if err != nil {
 		panic(err)
 	}

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -101,7 +101,7 @@ func VMStorage() vm.StorageMap {
 func MustSign(s types.MockSigner, msgs ...*types.Message) []*types.SignedMessage {
 	var smsgs []*types.SignedMessage
 	for _, m := range msgs {
-		sm, err := types.NewSignedMessage(*m, &s, types.NewGasPrice(0), types.NewGasCost(0))
+		sm, err := types.NewSignedMessage(*m, &s, types.NewGasPrice(0), types.NewGasUnits(0))
 		if err != nil {
 			panic(err)
 		}

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -12,8 +12,8 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 )
 
-// GasCost represents a unit of gas consumed
-type GasCost = Uint64
+// GasUnits represents number of units of gas consumed
+type GasUnits = Uint64
 
 var (
 	// ErrMessageSigned is returned when `Sign()` is called on a signedmessage that has previously been signed
@@ -33,7 +33,7 @@ type SignedMessage struct {
 	Message   `json:"message"`
 	Signature Signature `json:"signature"`
 	GasPrice  AttoFIL   `json:"gasPrice"`
-	GasLimit  GasCost   `json:"gasLimit"`
+	GasLimit  GasUnits  `json:"gasLimit"`
 }
 
 // Unmarshal a SignedMessage from the given bytes.
@@ -105,7 +105,7 @@ func (smsg *SignedMessage) String() string {
 
 // NewSignedMessage accepts a message `msg` and a signer `s`. NewSignedMessage returns a `SignedMessage` containing
 // a signature derived from the seralized `msg` and `msg.From`
-func NewSignedMessage(msg Message, s Signer, gasPrice AttoFIL, gasLimit GasCost) (*SignedMessage, error) {
+func NewSignedMessage(msg Message, s Signer, gasPrice AttoFIL, gasLimit GasUnits) (*SignedMessage, error) {
 	bmsg, err := msg.Marshal()
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func NewGasPrice(price int64) AttoFIL {
 	return *NewAttoFIL(big.NewInt(price))
 }
 
-// NewGasCost constructs a new GasCost from the given number.
-func NewGasCost(cost int64) GasCost {
+// NewGasUnits constructs a new GasUnits from the given number.
+func NewGasUnits(cost int64) GasUnits {
 	return Uint64(cost)
 }

--- a/types/testing.go
+++ b/types/testing.go
@@ -95,7 +95,7 @@ func NewSignedMessageForTestGetter(ms MockSigner) func() *SignedMessage {
 			NewAttoFILFromFIL(0),
 			s,
 			[]byte("params"))
-		smsg, err := NewSignedMessage(*msg, &ms, NewGasPrice(0), NewGasCost(0))
+		smsg, err := NewSignedMessage(*msg, &ms, NewGasPrice(0), NewGasUnits(0))
 		if err != nil {
 			panic(err)
 		}
@@ -192,7 +192,7 @@ func NewSignedMsgs(n int, ms MockSigner) []*SignedMessage {
 func SignMsgs(ms MockSigner, msgs []*Message) ([]*SignedMessage, error) {
 	var smsgs []*SignedMessage
 	for _, m := range msgs {
-		s, err := NewSignedMessage(*m, &ms, NewGasPrice(0), NewGasCost(0))
+		s, err := NewSignedMessage(*m, &ms, NewGasPrice(0), NewGasUnits(0))
 		if err != nil {
 			return nil, err
 		}

--- a/vm/context.go
+++ b/vm/context.go
@@ -25,7 +25,7 @@ type Context struct {
 	state       *state.CachedTree
 	storageMap  StorageMap
 	gasPrice    types.AttoFIL
-	gasLimit    types.GasCost
+	gasLimit    types.GasUnits
 	blockHeight *types.BlockHeight
 
 	deps *deps // Inject external dependencies so we can unit test robustly.
@@ -34,7 +34,7 @@ type Context struct {
 var _ exec.VMContext = (*Context)(nil)
 
 // NewVMContext returns an initialized context.
-func NewVMContext(from, to *actor.Actor, msg *types.Message, st *state.CachedTree, store StorageMap, gp types.AttoFIL, gl types.GasCost, bh *types.BlockHeight) *Context {
+func NewVMContext(from, to *actor.Actor, msg *types.Message, st *state.CachedTree, store StorageMap, gp types.AttoFIL, gl types.GasUnits, bh *types.BlockHeight) *Context {
 	return &Context{
 		from:        from,
 		to:          to,

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -45,7 +45,7 @@ func TestVMContextStorage(t *testing.T) {
 
 	to, err := cstate.GetActor(ctx, toAddr)
 	assert.NoError(err)
-	vmCtx := NewVMContext(nil, to, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+	vmCtx := NewVMContext(nil, to, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 
 	node, err := cbor.WrapObject([]byte("hello"), types.DefaultHashFunction, -1)
 	assert.NoError(err)
@@ -57,7 +57,7 @@ func TestVMContextStorage(t *testing.T) {
 	toActorBack, err := st.GetActor(ctx, toAddr)
 	assert.NoError(err)
 
-	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0)).ReadStorage()
+	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0)).ReadStorage()
 	assert.NoError(err)
 	assert.Equal(storage, node.RawData())
 }
@@ -88,7 +88,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -114,7 +114,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -145,7 +145,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(to, "foo", nil, []interface{}{})
@@ -176,7 +176,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -212,7 +212,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -228,7 +228,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		addr, err := vmctx.AddressForNewActor()
 
 		require.NoError(err)
@@ -259,10 +259,10 @@ func TestVMContextIsAccountActor(t *testing.T) {
 
 	accountActor, err := account.NewActor(types.NewAttoFILFromFIL(1000))
 	require.NoError(err)
-	ctx := NewVMContext(accountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasCost(0), nil)
+	ctx := NewVMContext(accountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), nil)
 	assert.True(ctx.IsFromAccountActor())
 
 	nonAccountActor := actor.NewActor(types.NewCidForTestGetter()(), types.NewAttoFILFromFIL(1000))
-	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasCost(0), nil)
+	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), nil)
 	assert.False(ctx.IsFromAccountActor())
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -67,7 +67,7 @@ func TestSendErrorHandling(t *testing.T) {
 		}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -84,7 +84,7 @@ func TestSendErrorHandling(t *testing.T) {
 		deps := sendDeps{}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -106,7 +106,7 @@ func TestSendErrorHandling(t *testing.T) {
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{
 			actor2.Code: &actor.FakeActor{},
 		}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasCost(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)

--- a/wallet/signature_test.go
+++ b/wallet/signature_test.go
@@ -116,7 +116,7 @@ func TestSignMessageOk(t *testing.T) {
 	fs, addr := requireSignerAddr(require)
 
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	assert.True(smsg.VerifySignature())
@@ -152,7 +152,7 @@ func TestSignedMessageBadSignature(t *testing.T) {
 
 	fs, addr := requireSignerAddr(require)
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	smsg.Signature[0] = smsg.Signature[0] ^ 0xFF
@@ -167,7 +167,7 @@ func TestSignedMessageCorrupted(t *testing.T) {
 	fs, addr := requireSignerAddr(require)
 
 	msg := types.NewMessage(addr, addr, 1, nil, "", nil)
-	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasCost(0))
+	smsg, err := types.NewSignedMessage(*msg, fs, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
 
 	smsg.Message.Nonce = types.Uint64(uint64(42))


### PR DESCRIPTION
# Problem

As @whyrusleeping pointed out in #1558, referring to the amount of gas consumed as GasCost is confusing, because "cost" suggests that some value is being transferred. This is not good, because this value is how we track gas consumption _prior_ to multiplying it by a `GasPrice` to get an amount of `AttoFIL` to transfer.

# Solution

The solution is to rename this type to `GasUnits`. Units is about as neutral a term as I can think of. We could leave the "Units" off and just call it "Gas", but Gas is always going to be a vague term which could refer to any part of the process of charging for message processing.