### PR TITLE
use an infinite loop in MakeProofAndWinningTicket

### DIFF
--- a/chain/testing.go
+++ b/chain/testing.go
@@ -305,8 +305,6 @@ func MakeProofAndWinningTicket(minerAddr address.Address, minerPower uint64, tot
 			return postProof, ticket, nil
 		}
 	}
-
-	return postProof, nil, errors.New("could not calculate a proof")
 }
 
 // These peer.ID generators were copied from libp2p/go-testutil. We didn't bring in the


### PR DESCRIPTION
A proposal to fix #1567.  The flakiness isn't just confined to TestTipSetWeightDeep, but anything calling MakeProofAndWinningTicket.  This includes default_syncer_test (17X). and anything calling CreateMinerWithPower, which calls RequireMineOnce, which calls this function 6X in default_syncer_test and 2X in power_table_view_test. One would expect this number of calls to increase over time.

The risk is that a given test using it will never exit.  Ok, never is a long time, but relatively way too long to be acceptable. This would introduce a different type of flakiness.

The alternative is to radically increase, but << infinity, the loop limit. This is guaranteed to have an occasional failure.  The larger the limit, the less frequent the failure, but it's already pretty small.