### PR TITLE
[BLOCKING] copy libutil.so.1 into final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 COPY --from=builder /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1
 COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/libgcc_s.so.1
+COPY --from=builder /lib/x86_64-linux-gnu/libutil.so.1 /lib/libutil.so.1
 COPY --from=builder $SRC_DIR/proofs/rust-proofs/target/release/libfilecoin_proofs.so /lib/libfilecoin_proofs.so
 COPY --from=builder $SRC_DIR/proofs/rust-proofs/target/release/libsector_base.so /lib/libsector_base.so
 

--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -18,6 +18,7 @@ COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/libgcc_s.so.1
+COPY --from=filecoin:all /lib/x86_64-linux-gnu/libutil.so.1 /lib/libutil.so.1
 COPY --from=filecoin:all $SRC_DIR/proofs/rust-proofs/target/release/libfilecoin_proofs.so /lib/libfilecoin_proofs.so
 COPY --from=filecoin:all $SRC_DIR/proofs/rust-proofs/target/release/libsector_base.so /lib/libsector_base.so
 


### PR DESCRIPTION
A dependency to `libutil.so.1` was introduced recently but that file is missing from the final Docker image, causing the the image to crash on start-up. 
This PR adds the file to the final image.