### PR TITLE
GAS: Add charge method to vmcontext

### DIFF
--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -107,7 +107,7 @@ func NewMockActor(list exec.Exports) *MockActor {
 
 func makeCtx(method string) exec.VMContext {
 	addrGetter := address.NewForTestGetter()
-	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 }
 
 func TestMakeTypedExportSuccess(t *testing.T) {

--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -222,6 +222,10 @@ func (ma *Actor) Exports() exec.Exports {
 // AddAsk adds an ask to this miners ask list
 func (ma *Actor) AddAsk(ctx exec.VMContext, price *types.AttoFIL, expiry *big.Int) (*big.Int, uint8,
 	error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		if ctx.Message().From != state.Owner {
@@ -268,6 +272,9 @@ func (ma *Actor) AddAsk(ctx exec.VMContext, price *types.AttoFIL, expiry *big.In
 // GetAsks returns all the asks for this miner. (TODO: this isnt a great function signature, it returns the asks in a
 // serialized array. Consider doing this some other way)
 func (ma *Actor) GetAsks(ctx exec.VMContext) ([]uint64, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		var askids []uint64
@@ -294,6 +301,10 @@ func (ma *Actor) GetAsks(ctx exec.VMContext) ([]uint64, uint8, error) {
 
 // GetAsk returns an ask by ID
 func (ma *Actor) GetAsk(ctx exec.VMContext, askid *big.Int) ([]byte, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		var ask *Ask
@@ -325,6 +336,10 @@ func (ma *Actor) GetAsk(ctx exec.VMContext, askid *big.Int) ([]byte, uint8, erro
 
 // GetOwner returns the miners owner.
 func (ma *Actor) GetOwner(ctx exec.VMContext) (address.Address, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return address.Address{}, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		return state.Owner, nil
@@ -343,6 +358,9 @@ func (ma *Actor) GetOwner(ctx exec.VMContext) (address.Address, uint8, error) {
 
 // GetLastUsedSectorID returns the last used sector id.
 func (ma *Actor) GetLastUsedSectorID(ctx exec.VMContext) (uint64, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return 0, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		return state.LastUsedSectorID, nil
@@ -361,6 +379,10 @@ func (ma *Actor) GetLastUsedSectorID(ctx exec.VMContext) (uint64, uint8, error) 
 
 // GetSectorCommitments returns all sector commitments posted by this miner.
 func (ma *Actor) GetSectorCommitments(ctx exec.VMContext) (map[string]types.Commitments, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		return state.SectorCommitments, nil
@@ -381,6 +403,9 @@ func (ma *Actor) GetSectorCommitments(ctx exec.VMContext) (map[string]types.Comm
 // The sector must not already be committed
 // 'size' is the total number of bytes stored in the sector
 func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR, commRStar []byte) (uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
 	if len(commD) != int(proofs.CommitmentBytesLen) {
 		return 0, errors.NewRevertError("invalid sized commD")
 	}
@@ -439,6 +464,10 @@ func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR,
 
 // GetKey returns the public key for this miner.
 func (ma *Actor) GetKey(ctx exec.VMContext) ([]byte, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	out, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		return state.PublicKey, nil
@@ -457,6 +486,10 @@ func (ma *Actor) GetKey(ctx exec.VMContext) ([]byte, uint8, error) {
 
 // GetPeerID returns the libp2p peer ID that this miner can be reached at.
 func (ma *Actor) GetPeerID(ctx exec.VMContext) (peer.ID, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return peer.ID(""), exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 
 	chunk, err := ctx.ReadStorage()
@@ -473,6 +506,10 @@ func (ma *Actor) GetPeerID(ctx exec.VMContext) (peer.ID, uint8, error) {
 
 // UpdatePeerID is used to update the peerID this miner is operating under.
 func (ma *Actor) UpdatePeerID(ctx exec.VMContext, pid peer.ID) (uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var storage State
 	_, err := actor.WithState(ctx, &storage, func() (interface{}, error) {
 		// verify that the caller is authorized to perform update
@@ -493,6 +530,10 @@ func (ma *Actor) UpdatePeerID(ctx exec.VMContext, pid peer.ID) (uint8, error) {
 
 // GetPledge returns the number of pledged sectors
 func (ma *Actor) GetPledge(ctx exec.VMContext) (*big.Int, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	ret, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		return state.PledgeSectors, nil
@@ -511,6 +552,10 @@ func (ma *Actor) GetPledge(ctx exec.VMContext) (*big.Int, uint8, error) {
 
 // GetPower returns the amount of proven sectors for this miner.
 func (ma *Actor) GetPower(ctx exec.VMContext) (*big.Int, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	ret, err := actor.WithState(ctx, &state, func() (interface{}, error) {
 		return state.Power, nil
@@ -530,6 +575,10 @@ func (ma *Actor) GetPower(ctx exec.VMContext) (*big.Int, uint8, error) {
 // SubmitPoSt is used to submit a coalesced PoST to the chain to convince the chain
 // that you have been actually storing the files you claim to be.
 func (ma *Actor) SubmitPoSt(ctx exec.VMContext, proof []byte) (uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	if len(proof) != PoStProofLength {
 		return 0, errors.NewRevertError("invalid sized proof")
 	}
@@ -590,6 +639,10 @@ func (ma *Actor) SubmitPoSt(ctx exec.VMContext, proof []byte) (uint8, error) {
 
 // GetProvingPeriodStart returns the current ProvingPeriodStart value.
 func (ma *Actor) GetProvingPeriodStart(ctx exec.VMContext) (*types.BlockHeight, uint8, error) {
+	if err := ctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	chunk, err := ctx.ReadStorage()
 	if err != nil {
 		return nil, errors.CodeError(err), err

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -132,6 +132,10 @@ var paymentBrokerExports = exec.Exports{
 // The value attached to the invocation is used as the deposit, and the channel
 // will expire and return all of its money to the owner after the given block height.
 func (pb *Actor) CreateChannel(vmctx exec.VMContext, target address.Address, eol *types.BlockHeight) (*types.ChannelID, uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	// require that from account be an account actor to ensure nonce is a valid id
 	if !vmctx.IsFromAccountActor() {
 		return nil, errors.CodeError(Errors[ErrNonAccountActor]), Errors[ErrNonAccountActor]
@@ -190,6 +194,10 @@ func (pb *Actor) CreateChannel(vmctx exec.VMContext, target address.Address, eol
 // target Close(500)           -> Payer: 1500, Target: 500, Channel: 0
 //
 func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types.ChannelID, amt *types.AttoFIL, validAt *types.BlockHeight, sig []byte) (uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	data := createVoucherSignatureData(chid, amt, validAt)
 	if !types.IsValidSignature(data, payer, sig) {
 		return errors.CodeError(Errors[ErrInvalidSignature]), Errors[ErrInvalidSignature]
@@ -237,6 +245,10 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 // Close first executes the logic performed in the the Update method, then returns all
 // funds remaining in the channel to the payer account and deletes the channel.
 func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.ChannelID, amt *types.AttoFIL, validAt *types.BlockHeight, sig []byte) (uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	data := createVoucherSignatureData(chid, amt, validAt)
 	if !types.IsValidSignature(data, payer, sig) {
 		return errors.CodeError(Errors[ErrInvalidSignature]), Errors[ErrInvalidSignature]
@@ -288,6 +300,10 @@ func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.
 // Extend can be used by the owner of a channel to add more funds to it and
 // extend the Channel's lifespan.
 func (pb *Actor) Extend(vmctx exec.VMContext, chid *types.ChannelID, eol *types.BlockHeight) (uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	ctx := context.Background()
 	storage := vmctx.Storage()
 	payerAddress := vmctx.Message().From
@@ -334,6 +350,10 @@ func (pb *Actor) Extend(vmctx exec.VMContext, chid *types.ChannelID, eol *types.
 // Reclaim is used by the owner of a channel to reclaim unspent funds in timed
 // out payment Channels they own.
 func (pb *Actor) Reclaim(vmctx exec.VMContext, chid *types.ChannelID) (uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	ctx := context.Background()
 	storage := vmctx.Storage()
 	payerAddress := vmctx.Message().From
@@ -378,6 +398,10 @@ func (pb *Actor) Reclaim(vmctx exec.VMContext, chid *types.ChannelID) (uint8, er
 // Voucher errors if the channel doesn't exist or contains less than request
 // amount.
 func (pb *Actor) Voucher(vmctx exec.VMContext, chid *types.ChannelID, amount *types.AttoFIL, validAt *types.BlockHeight) ([]byte, uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return []byte{}, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	ctx := context.Background()
 	storage := vmctx.Storage()
 	payerAddress := vmctx.Message().From
@@ -435,6 +459,10 @@ func (pb *Actor) Voucher(vmctx exec.VMContext, chid *types.ChannelID, amount *ty
 // Ls returns all payment channels for a given payer address.
 // The slice of channels will be returned as cbor encoded map from string channelId to PaymentChannel.
 func (pb *Actor) Ls(vmctx exec.VMContext, payer address.Address) ([]byte, uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return []byte{}, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	ctx := context.Background()
 	storage := vmctx.Storage()
 	channels := map[string]*PaymentChannel{}

--- a/actor/builtin/storagemarket/storagemarket.go
+++ b/actor/builtin/storagemarket/storagemarket.go
@@ -107,6 +107,10 @@ var storageMarketExports = exec.Exports{
 // CreateMiner creates a new miner with the a pledge of the given amount of sectors. The
 // miners collateral is set by the value in the message.
 func (sma *Actor) CreateMiner(vmctx exec.VMContext, pledge *big.Int, publicKey []byte, pid peer.ID) (address.Address, uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return address.Address{}, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		if pledge.Cmp(MinimumPledge) < 0 {
@@ -153,6 +157,10 @@ func (sma *Actor) CreateMiner(vmctx exec.VMContext, pledge *big.Int, publicKey [
 // This occurs either when a miner adds a new commitment, or when one is removed
 // (via slashing or willful removal). The delta is in number of sectors.
 func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *big.Int) (uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	_, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		miner := vmctx.Message().From
@@ -184,6 +192,10 @@ func (sma *Actor) UpdatePower(vmctx exec.VMContext, delta *big.Int) (uint8, erro
 
 // GetTotalStorage returns the total amount of proven storage in the system.
 func (sma *Actor) GetTotalStorage(vmctx exec.VMContext) (*big.Int, uint8, error) {
+	if err := vmctx.Charge(100); err != nil {
+		return nil, exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
+	}
+
 	var state State
 	ret, err := actor.WithState(vmctx, &state, func() (interface{}, error) {
 		return state.TotalCommittedStorage, nil

--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -77,7 +77,7 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 		"miner", "update-peerid",
 		"--from", addr,
 		"--price", "0",
-		"--limit", "0",
+		"--limit", "100",
 		minerAddr,
 		minerPidForUpdate.Pretty(),
 	)

--- a/commands/main.go
+++ b/commands/main.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"github.com/filecoin-project/go-filecoin/types"
 	"net"
 	"net/url"
@@ -303,9 +304,9 @@ func isConnectionRefused(err error) bool {
 }
 
 var priceOption = cmdkit.StringOption("price", "Price (FIL e.g. 0.00013) to pay for each GasUnits consumed mining this message")
-var limitOption = cmdkit.Int64Option("limit", "Maximum number of GasUnits this message is allowed to consume")
+var limitOption = cmdkit.Uint64Option("limit", "Maximum number of GasUnits this message is allowed to consume")
 
-func parseGasOptions(req *cmds.Request) (gasPrice types.AttoFIL, gasCost types.GasUnits, error error) {
+func parseGasOptions(req *cmds.Request) (gasPrice types.AttoFIL, gasLimit types.GasUnits, error error) {
 	priceOption := req.Options["price"]
 	if priceOption == nil {
 		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("price option is required")
@@ -316,12 +317,11 @@ func parseGasOptions(req *cmds.Request) (gasPrice types.AttoFIL, gasCost types.G
 		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("invalid gas price (specify FIL as a decimal number)")
 	}
 
-	gasLimitInt, ok := req.Options["limit"].(int64)
+	gasLimitInt, ok := req.Options["limit"].(uint64)
+
 	if !ok {
-		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("invalid gas limit")
-	}
-	if gasLimitInt < 0 {
-		return types.AttoFIL{}, types.NewGasUnits(0), errors.New("gas limit cannot be less than zero")
+		msg := fmt.Sprintf("invalid gas limit: %s", req.Options["limit"].(string))
+		return types.AttoFIL{}, types.NewGasUnits(0), errors.New(msg)
 	}
 
 	return *price, types.NewGasUnits(gasLimitInt), nil

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -33,7 +33,7 @@ func TestPaymentChannelCreateSuccess(t *testing.T) {
 	defer d.ShutdownSuccess()
 
 	args := []string{"paych", "create"}
-	args = append(args, "--from", fixtures.TestAddresses[0], "--price", "0", "--limit", "0")
+	args = append(args, "--from", fixtures.TestAddresses[0], "--price", "0", "--limit", "300")
 	args = append(args, fixtures.TestAddresses[1], "10000", "20")
 
 	paymentChannelCmd := d.RunSuccess(args...)
@@ -346,7 +346,7 @@ func daemonTestWithPaymentChannel(t *testing.T, payerAddress *address.Address, t
 	defer d.ShutdownSuccess()
 
 	args := []string{"paych", "create"}
-	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "0")
+	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "300")
 	args = append(args, targetAddress.String(), fundsToLock.String(), eol.String())
 
 	paymentChannelCmd := d.RunSuccess(args...)
@@ -409,7 +409,7 @@ func mustExtendChannel(t *testing.T, d *th.TestDaemon, channelID *types.ChannelI
 	require := require.New(t)
 
 	args := []string{"paych", "extend"}
-	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "0")
+	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "300")
 	args = append(args, channelID.String(), amount.String(), eol.String())
 
 	redeemCmd := d.RunSuccess(args...)
@@ -439,7 +439,7 @@ func mustRedeemVoucher(t *testing.T, d *th.TestDaemon, voucher string, targetAdd
 	require := require.New(t)
 
 	args := []string{"paych", "redeem", voucher}
-	args = append(args, "--from", targetAddress.String(), "--price", "0", "--limit", "0")
+	args = append(args, "--from", targetAddress.String(), "--price", "0", "--limit", "300")
 
 	redeemCmd := d.RunSuccess(args...)
 	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
@@ -468,7 +468,7 @@ func mustCloseChannel(t *testing.T, d *th.TestDaemon, voucher paymentbroker.Paym
 	require := require.New(t)
 
 	args := []string{"paych", "close", mustEncodeVoucherStr(t, voucher)}
-	args = append(args, "--from", targetAddress.String(), "--price", "0", "--limit", "0")
+	args = append(args, "--from", targetAddress.String(), "--price", "0", "--limit", "300")
 
 	redeemCmd := d.RunSuccess(args...)
 	messageCid, err := cid.Parse(strings.Trim(redeemCmd.ReadStdout(), "\n"))
@@ -497,7 +497,7 @@ func mustReclaimChannel(t *testing.T, d *th.TestDaemon, channelID *types.Channel
 	require := require.New(t)
 
 	args := []string{"paych", "reclaim", channelID.String()}
-	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "0")
+	args = append(args, "--from", payerAddress.String(), "--price", "0", "--limit", "300")
 
 	reclaimCmd := d.RunSuccess(args...)
 	messageCid, err := cid.Parse(strings.Trim(reclaimCmd.ReadStdout(), "\n"))

--- a/consensus/testing.go
+++ b/consensus/testing.go
@@ -1,0 +1,108 @@
+package consensus
+
+import (
+	"context"
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/state"
+	"github.com/filecoin-project/go-filecoin/types"
+	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestView is an implementation of stateView used for testing the chain
+// manager.  It provides a consistent view that the storage market
+// that returns 1 for storage total and 1 for any miner storage.
+type TestView struct{}
+
+var _ PowerTableView = &TestView{}
+
+// Total always returns 1.
+func (tv *TestView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
+	return uint64(1), nil
+}
+
+// Miner always returns 1.
+func (tv *TestView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
+	return uint64(1), nil
+}
+
+// HasPower always returns true.
+func (tv *TestView) HasPower(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) bool {
+	return true
+}
+
+// RequireNewTipSet instantiates and returns a new tipset of the given blocks
+// and requires that the setup validation succeed.
+func RequireNewTipSet(require *require.Assertions, blks ...*types.Block) TipSet {
+	ts, err := NewTipSet(blks...)
+	require.NoError(err)
+	return ts
+}
+
+// RequireTipSetAdd adds a block to the provided tipset and requires that this
+// does not error.
+func RequireTipSetAdd(require *require.Assertions, blk *types.Block, ts TipSet) {
+	err := ts.AddBlock(blk)
+	require.NoError(err)
+}
+
+// TestPowerTableView is an implementation of the powertable view used for testing mining
+// wherein each miner has totalPower/minerPower power.
+type TestPowerTableView struct{ minerPower, totalPower uint64 }
+
+// NewTestPowerTableView creates a test power view with the given total power
+func NewTestPowerTableView(minerPower uint64, totalPower uint64) *TestPowerTableView {
+	return &TestPowerTableView{minerPower: minerPower, totalPower: totalPower}
+}
+
+// Total always returns value that was supplied to NewTestPowerTableView.
+func (tv *TestPowerTableView) Total(ctx context.Context, st state.Tree, bstore blockstore.Blockstore) (uint64, error) {
+	return tv.totalPower, nil
+}
+
+// Miner always returns value that was supplied to NewTestPowerTableView.
+func (tv *TestPowerTableView) Miner(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) (uint64, error) {
+	return tv.minerPower, nil
+}
+
+// HasPower always returns true.
+func (tv *TestPowerTableView) HasPower(ctx context.Context, st state.Tree, bstore blockstore.Blockstore, mAddr address.Address) bool {
+	return true
+}
+
+// TestSignedMessageValidator is a validator that doesn't validate to simplify message creation in tests.
+type TestSignedMessageValidator struct{}
+
+var _ SignedMessageValidator = (*TestSignedMessageValidator)(nil)
+
+// Validate always returns nil
+func (tsmv *TestSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor, bh *types.BlockHeight) error {
+	return nil
+}
+
+// TestBlockRewarder is a rewarder that doesn't actually add any rewards to simplify state tracking in tests
+type TestBlockRewarder struct{}
+
+var _ BlockRewarder = (*TestBlockRewarder)(nil)
+
+// BlockReward is a noop
+func (tbr *TestBlockRewarder) BlockReward(ctx context.Context, st state.Tree, minerAddr address.Address) error {
+	// do nothing to keep state root the same
+	return nil
+}
+
+// GasReward is a noop
+func (tbr *TestBlockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, gas *types.AttoFIL) error {
+	// do nothing to keep state root the same
+	return nil
+}
+
+// NewTestProcessor creates a processor with a test validator and test rewarder
+func NewTestProcessor() Processor {
+	return &DefaultProcessor{
+		signedMessageValidator: &TestSignedMessageValidator{},
+		blockRewarder:          &TestBlockRewarder{},
+	}
+}

--- a/exec/exec.go
+++ b/exec/exec.go
@@ -24,6 +24,8 @@ const (
 	ErrDanglingPointer = 34
 	// ErrStaleHead indicates that an actor attempted to commit over a stale chunk
 	ErrStaleHead = 35
+	// ErrInsufficientGas indicates that an actor did not have sufficient gas to run a message
+	ErrInsufficientGas = 36
 )
 
 // Errors map error codes to revert errors this actor may return
@@ -71,6 +73,7 @@ type VMContext interface {
 	AddressForNewActor() (address.Address, error)
 	BlockHeight() *types.BlockHeight
 	IsFromAccountActor() bool
+	Charge(cost types.GasUnits) error
 
 	CreateNewActor(addr address.Address, code cid.Cid, initalizationParams interface{}) error
 

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -168,13 +168,13 @@ function wait_mpool_size {
 
 function add_ask {
   ./go-filecoin miner add-ask "$1" "$2" "$3" \
-    --price=0 --limit=0 \
+    --price=0 --limit=300 \
     --repodir="$4"
 }
 
 function miner_update_pid {
   ./go-filecoin miner update-peerid "$1" "$2" \
-    --price=0 --limit=0 \
+    --price=0 --limit=300 \
     --repodir="$3"
 }
 

--- a/gengen/main.go
+++ b/gengen/main.go
@@ -85,6 +85,7 @@ func main() {
 	}
 	info, err := gengen.GenGenesisCar(cfg, outfile, *seed)
 	if err != nil {
+		fmt.Println("ERROR", err)
 		panic(err)
 	}
 

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -313,7 +313,9 @@ func GenGenesisCar(cfg *GenesisCfg, out io.Writer, seed int64) (*RenderedGenInfo
 func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, from, to address.Address, value *types.AttoFIL, method string, params ...interface{}) ([]types.Bytes, error) {
 	pdata := actor.MustConvertParams(params...)
 	msg := types.NewMessage(from, to, 0, value, method, pdata)
-	smsg, err := types.NewSignedMessage(*msg, &signer{}, types.NewGasPrice(0), types.NewGasUnits(0))
+	// this should never fail due to lack of gas since gas doesn't have meaning here
+	gasLimit := types.NewGasUnits(types.MaxGasUnits)
+	smsg, err := types.NewSignedMessage(*msg, &signer{}, types.NewGasPrice(0), gasLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +356,11 @@ var _ consensus.BlockRewarder = (*blockRewarder)(nil)
 
 // BlockReward is a noop
 func (gbr *blockRewarder) BlockReward(ctx context.Context, st state.Tree, minerAddr address.Address) error {
-	// do nothing to keep state root the same
+	return nil
+}
+
+// GasReward is a noop
+func (gbr *blockRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost *types.AttoFIL) error {
 	return nil
 }
 

--- a/node/block_propagate_test.go
+++ b/node/block_propagate_test.go
@@ -131,6 +131,10 @@ func (r *zeroRewarder) BlockReward(ctx context.Context, st state.Tree, minerAddr
 	return nil
 }
 
+func (r *zeroRewarder) GasReward(ctx context.Context, st state.Tree, minerAddr address.Address, msg *types.SignedMessage, cost *types.AttoFIL) error {
+	return nil
+}
+
 func makeNodes(ctx context.Context, t *testing.T, assertions *assert.Assertions) (address.Address, []*Node) {
 	seed := MakeChainSeed(t, TestGenCfg)
 	configOpts := []ConfigOpt{RewarderConfigOption(&zeroRewarder{})}

--- a/node/node.go
+++ b/node/node.go
@@ -738,13 +738,13 @@ func (node *Node) StartMining(ctx context.Context) error {
 
 					// TODO: determine these algorithmically by simulating call and querying historical prices
 					gasPrice := types.NewGasPrice(0)
-					gasCost := types.NewGasUnits(0)
+					gasUnits := types.NewGasUnits(types.MaxGasUnits)
 
 					val := result.SealingResult
 					// This call can fail due to, e.g. nonce collisions, so we retry to make sure we include it,
 					// as our miners existence depends on this.
 					// TODO: what is the right number of retries?
-					err := porcelain.MessageSendWithRetry(node.miningCtx, node.PlumbingAPI, 10 /* retries */, node.GetBlockTime() /* wait per retry */, minerOwnerAddr, minerAddr, nil, "commitSector", gasPrice, gasCost, val.SectorID, val.CommD[:], val.CommR[:], val.CommRStar[:])
+					err := porcelain.MessageSendWithRetry(node.miningCtx, node.PlumbingAPI, 10 /* retries */, node.GetBlockTime() /* wait per retry */, minerOwnerAddr, minerAddr, nil, "commitSector", gasPrice, gasUnits, val.SectorID, val.CommD[:], val.CommR[:], val.CommRStar[:])
 					if err != nil {
 						log.Errorf("failed to send commitSector message from %s to %s for sector with id %d: %s", minerOwnerAddr, minerAddr, val.SectorID, err)
 						continue

--- a/state/testing.go
+++ b/state/testing.go
@@ -110,7 +110,7 @@ func (m *MockStateTree) Debug() {
 func (m *MockStateTree) GetBuiltinActorCode(c cid.Cid) (exec.ExecutableActor, error) {
 	a, ok := m.BuiltinActors[c]
 	if !ok {
-		return nil, fmt.Errorf("unknown actor: %s", c)
+		return nil, fmt.Errorf("unknown actor: %v", c.String())
 	}
 
 	return a, nil

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -488,7 +488,7 @@ func (td *TestDaemon) CreateAsk(peer *TestDaemon, minerAddr string, fromAddr str
 	wg.Add(1)
 
 	go func() {
-		ask := td.RunSuccess("miner", "add-ask", "--from", fromAddr, "--price", "0", "--limit", "0", minerAddr, price, expiry)
+		ask := td.RunSuccess("miner", "add-ask", "--from", fromAddr, "--price", "0", "--limit", "300", minerAddr, price, expiry)
 		askCid, err := cid.Parse(strings.Trim(ask.ReadStdout(), "\n"))
 		require.NoError(td.test, err)
 		assert.NotNil(td.test, askCid)

--- a/testhelpers/core.go
+++ b/testhelpers/core.go
@@ -2,12 +2,13 @@ package testhelpers
 
 import (
 	"context"
+	"math/big"
+
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmRXf2uUSdGSunRJsM9wXSUNVwLUGCY3So5fAs7h2CBJVf/go-hamt-ipld"
 	"gx/ipfs/QmS2aqUZLJp8kF1ihE5rvDGE5LvmKDPnx32w9Z1BW9xLV5/go-ipfs-blockstore"
 	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
 	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore"
-	"math/big"
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin"
@@ -101,7 +102,8 @@ func VMStorage() vm.StorageMap {
 func MustSign(s types.MockSigner, msgs ...*types.Message) []*types.SignedMessage {
 	var smsgs []*types.SignedMessage
 	for _, m := range msgs {
-		sm, err := types.NewSignedMessage(*m, &s, types.NewGasPrice(0), types.NewGasUnits(0))
+		gasLimit := types.NewGasUnits(999)
+		sm, err := types.NewSignedMessage(*m, &s, types.NewGasPrice(0), gasLimit)
 		if err != nil {
 			panic(err)
 		}

--- a/types/message_receipt.go
+++ b/types/message_receipt.go
@@ -17,4 +17,7 @@ type MessageReceipt struct {
 	// This can be non-empty even in the case of error (e.g., to provide
 	// programmatically readable detail about errors).
 	Return []Bytes `json:"return"`
+
+	// GasAttoFIL Charge is the actual amount of FIL transferred from the sender to the miner for processing the message
+	GasAttoFIL *AttoFIL `json:"gasAttoFIL"`
 }

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -15,6 +15,10 @@ import (
 // GasUnits represents number of units of gas consumed
 type GasUnits = Uint64
 
+// MaxGasUnits is a convenience value for when we want to guarantee a direct message does not fail due
+//    to lack of gas
+const MaxGasUnits = ^uint64(0)
+
 var (
 	// ErrMessageSigned is returned when `Sign()` is called on a signedmessage that has previously been signed
 	ErrMessageSigned = errors.New("message already contains a signature")
@@ -130,6 +134,6 @@ func NewGasPrice(price int64) AttoFIL {
 }
 
 // NewGasUnits constructs a new GasUnits from the given number.
-func NewGasUnits(cost int64) GasUnits {
+func NewGasUnits(cost uint64) GasUnits {
 	return Uint64(cost)
 }

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -45,7 +45,7 @@ func TestVMContextStorage(t *testing.T) {
 
 	to, err := cstate.GetActor(ctx, toAddr)
 	assert.NoError(err)
-	vmCtx := NewVMContext(nil, to, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+	vmCtx := NewVMContext(nil, to, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 
 	node, err := cbor.WrapObject([]byte("hello"), types.DefaultHashFunction, -1)
 	assert.NoError(err)
@@ -57,7 +57,7 @@ func TestVMContextStorage(t *testing.T) {
 	toActorBack, err := st.GetActor(ctx, toAddr)
 	assert.NoError(err)
 
-	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0)).ReadStorage()
+	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0)).ReadStorage()
 	assert.NoError(err)
 	assert.Equal(storage, node.RawData())
 }
@@ -88,7 +88,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -114,7 +114,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -145,7 +145,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(to, "foo", nil, []interface{}{})
@@ -176,7 +176,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -212,7 +212,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -228,7 +228,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		addr, err := vmctx.AddressForNewActor()
 
 		require.NoError(err)
@@ -259,10 +259,10 @@ func TestVMContextIsAccountActor(t *testing.T) {
 
 	accountActor, err := account.NewActor(types.NewAttoFILFromFIL(1000))
 	require.NoError(err)
-	ctx := NewVMContext(accountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), nil)
+	ctx := NewVMContext(accountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), nil)
 	assert.True(ctx.IsFromAccountActor())
 
 	nonAccountActor := actor.NewActor(types.NewCidForTestGetter()(), types.NewAttoFILFromFIL(1000))
-	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), nil)
+	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), nil)
 	assert.False(ctx.IsFromAccountActor())
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -67,7 +67,7 @@ func TestSendErrorHandling(t *testing.T) {
 		}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -84,7 +84,7 @@ func TestSendErrorHandling(t *testing.T) {
 		deps := sendDeps{}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -106,7 +106,7 @@ func TestSendErrorHandling(t *testing.T) {
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{
 			actor2.Code: &actor.FakeActor{},
 		}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)


### PR DESCRIPTION
Closes #912

## Problem

We need to charge gas so miners have an incentive to process messages. Specifically actors need a mechanism to charge for resources consumed, and we need to process that charge in such a way the filecoin is transferred from the sender to the miner.

## Solution

Earlier work added gas price and gas limit to messages and validated the sender had sufficient funds to cover the maximum gas cost. This work adds a `Charge` method to `VMContext`. Actors can call this method at any point with any value that makes since to charge for resources consumed. In the current work, all actors charge a uniform amount at the beginning of the execution.

## Things to look out for: 

1. In processor.go:ApplyMessage: We add the logic to transfer funds from the sender to the miner. It's critical that payment happens regardless of whether the message succeeds or fails, so notice that the transfer happens after the cachedStateTree.Commit() for the main message transaction.
2. In message_recept.go: We've added a `Gas` field to account for how much gas was transferred from the sender to the miner.
3. In context.go: We've added the `Charge` method. It's not very complicated.
4. in context.go:Send: We've added logic to initialize the nested message's context with gas consumed so far, and then add the gas consumed by the nested message back to the parent message to keep track of the total.

__NOTE: The goal of this PR is add functionality to permit charging, not to charge in a way that accurately reflects resources consumed__