### PR TITLE
Remove Coverage Badge From README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # Filecoin (go-filecoin)
 
 [![CircleCI](https://circleci.com/gh/filecoin-project/go-filecoin.svg?style=svg&circle-token=5a9d1cb48788b41d98bdfbc8b15298816ec71fea)](https://circleci.com/gh/filecoin-project/go-filecoin)
-[![codecov](https://codecov.io/gh/filecoin-project/go-filecoin/branch/master/graph/badge.svg?token=J5QWYWkgHT)](https://codecov.io/gh/filecoin-project/go-filecoin)	
 
 > Filecoin implementation in Go, turning the world’s unused storage into an algorithmic market.
 


### PR DESCRIPTION
We remove the coverage badge from the README, as we are no longer using Codecov with this repository.