### PR TITLE
Deals with the same data and different miners

### DIFF
--- a/protocol/storage/client.go
+++ b/protocol/storage/client.go
@@ -90,10 +90,11 @@ func (smc *Client) ProposeDeal(ctx context.Context, miner address.Address, data 
 	}
 
 	proposal := &DealProposal{
-		PieceRef:   data,
-		Size:       types.NewBytesAmount(size),
-		TotalPrice: price,
-		Duration:   duration,
+		PieceRef:     data,
+		Size:         types.NewBytesAmount(size),
+		TotalPrice:   price,
+		Duration:     duration,
+		MinerAddress: miner,
 		//Payment:    PaymentInfo{},
 		//Signature:  nil, // TODO: sign this
 	}

--- a/protocol/storage/types.go
+++ b/protocol/storage/types.go
@@ -4,6 +4,7 @@ import (
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
 
+	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
 )
 
@@ -30,6 +31,9 @@ type DealProposal struct {
 
 	// LastDuplicate is a string of the CID of the last deal proposal with the same properties, or an empty string if no such deal exists
 	LastDuplicate string
+
+	// MinerAddress is the address of the storage miner in the deal proposal
+	MinerAddress address.Address
 
 	// TODO: Payment PaymentInfo
 	// Signature types.Signature


### PR DESCRIPTION
Add the ability for a single storage client to make a storage deal with
different storage miners and the same data.

Additionally, clean up the `AddAsk` test helper.

Change to the spec: https://github.com/filecoin-project/specs/pull/104

Resolves #1143 