### PR TITLE
implement Actions around wallet and address commands

### DIFF
--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-filecoin/commands"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
 	iptbtester "github.com/filecoin-project/go-filecoin/testhelpers/iptbtester"
 )
@@ -25,10 +26,6 @@ func init() {
 	if _, err := os.Stat(faucetBinary); os.IsNotExist(err) {
 		panic("faucet not found, run `go run build/*.go build` to fix")
 	}
-}
-
-type addressResult struct {
-	Address string
 }
 
 func TestFaucetSendFunds(t *testing.T) {
@@ -79,13 +76,13 @@ func TestFaucetSendFunds(t *testing.T) {
 	defer faucetcancel()
 
 	// Get address for target node
-	var targetAddr addressResult
+	var targetAddr commands.AddressLsResult
 	node1.MustRunCmdJSON(ctx, &targetAddr, "go-filecoin", "wallet", "addrs", "ls")
 
 	// Start Tests
 
 	// Make request for funds
-	msgcid := MustSendFundsFaucet(t, "localhost:9797", targetAddr.Address)
+	msgcid := MustSendFundsFaucet(t, "localhost:9797", targetAddr.Addresses[0])
 
 	// Wait around for message to appear
 	msgctx, msgcancel := context.WithTimeout(context.Background(), blockTime*3)
@@ -94,7 +91,7 @@ func TestFaucetSendFunds(t *testing.T) {
 
 	// Read wallet balance
 	var balanceStr string
-	node1.MustRunCmdJSON(ctx, &balanceStr, "go-filecoin", "wallet", "balance", targetAddr.Address)
+	node1.MustRunCmdJSON(ctx, &balanceStr, "go-filecoin", "wallet", "balance", targetAddr.Addresses[0])
 	balance, err := strconv.ParseInt(balanceStr, 10, 64)
 	require.NoError(err)
 

--- a/functional-tests/lib/helpers.bash
+++ b/functional-tests/lib/helpers.bash
@@ -42,8 +42,7 @@ function free_port {
 
 function import_private_key {
   ./go-filecoin wallet import ./fixtures/"$1".key \
-    --repodir="$2" \
-    | jq -r ""
+    --repodir="$2"
 }
 
 function init_local_daemon {

--- a/testhelpers/fat/action_address.go
+++ b/testhelpers/fat/action_address.go
@@ -1,0 +1,49 @@
+package fat
+
+import (
+	"context"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/commands"
+
+	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
+)
+
+// AddressNew runs the address new command against the filecoin process.
+func (f *Filecoin) AddressNew(ctx context.Context) (address.Address, error) {
+	var newAddress address.Address
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &newAddress, "go-filecoin", "address", "new"); err != nil {
+		return address.Address{}, err
+	}
+	return newAddress, nil
+}
+
+// AddressLs runs the address ls command against the filecoin process.
+func (f *Filecoin) AddressLs(ctx context.Context) ([]address.Address, error) {
+	// the command returns an AddressListResult
+	var alr commands.AddressLsResult
+	// we expect to interact with an array of address
+	var out []address.Address
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &alr, "go-filecoin", "address", "ls"); err != nil {
+		return nil, err
+	}
+
+	// transform the AddressListResult to an array of addresses
+	for _, addr := range alr.Addresses {
+		a, err := address.NewFromString(addr)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// AddressLookup runs the address lookup command against the filecoin process.
+func (f *Filecoin) AddressLookup(ctx context.Context, addr address.Address) (peer.ID, error) {
+	var ownerPeer peer.ID
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &ownerPeer, "go-filecoin", "address", "lookup", addr.String()); err != nil {
+		return "", err
+	}
+	return ownerPeer, nil
+}

--- a/testhelpers/fat/action_wallet.go
+++ b/testhelpers/fat/action_wallet.go
@@ -1,0 +1,62 @@
+package fat
+
+import (
+	"context"
+	"strings"
+
+	"gx/ipfs/QmXWZCd8jfaHmt4UDSnjKmGcrQMw95bDGWqEeVLVJjoANX/go-ipfs-files"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/commands"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// WalletBalance run the wallet balance command against the filecoin process.
+func (f *Filecoin) WalletBalance(ctx context.Context, addr address.Address) (*types.AttoFIL, error) {
+	var balance *types.AttoFIL
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &balance, "go-filecoin", "wallet", "balance", addr.String()); err != nil {
+		return nil, err
+	}
+	return balance, nil
+}
+
+// WalletImport run the wallet import command against the filecoin process.
+func (f *Filecoin) WalletImport(ctx context.Context, file files.File) ([]address.Address, error) {
+	// the command returns an AddressListResult
+	var alr commands.AddressLsResult
+	// we expect to interact with an array of address
+	var out []address.Address
+
+	if err := f.RunCmdJSONWithStdin(ctx, file, &alr, "go-filecoin", "wallet", "import"); err != nil {
+		return nil, err
+	}
+
+	// transform the AddressListResult to an array of addresses
+	for _, addr := range alr.Addresses {
+		a, err := address.NewFromString(addr)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// WalletExport run the wallet export command against the filecoin process.
+func (f *Filecoin) WalletExport(ctx context.Context, addrs []address.Address) ([]*types.KeyInfo, error) {
+	// the command returns an KeyInfoListResult
+	var klr commands.WalletExportResult
+	// we expect to interact with an array of KeyInfo(s)
+	var out []*types.KeyInfo
+	var sAddrs []string
+	for _, a := range addrs {
+		sAddrs = append(sAddrs, a.String())
+	}
+
+	if err := f.RunCmdJSONWithStdin(ctx, nil, &klr, "go-filecoin", "wallet", "export", strings.Join(sAddrs, " ")); err != nil {
+		return nil, err
+	}
+
+	// transform the KeyInfoListResult to an array of KeyInfo(s)
+	return append(out, klr.KeyInfo...), nil
+}


### PR DESCRIPTION
closes #1666

### Description

This PR implements FAT actions wrappers around the go-filecoin wallet and address commands.