### PR TITLE
set-price command & require price in deal proposals

### DIFF
--- a/commands/env.go
+++ b/commands/env.go
@@ -34,7 +34,7 @@ func GetAPI(env cmds.Environment) api.API {
 	return ce.API()
 }
 
-// GetPlumbingAPI returns the api2.Filecoin interface from the environment.
+// GetPlumbingAPI returns the plumbing.API interface from the environment.
 func GetPlumbingAPI(env cmds.Environment) *plumbing.API {
 	ce := env.(*Env)
 	return ce.plumbingAPI

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // Config is an in memory representation of the filecoin configuration file
@@ -101,12 +102,14 @@ func newDefaultBootstrapConfig() *BootstrapConfig {
 type MiningConfig struct {
 	MinerAddress            address.Address `json:"minerAddress"`
 	AutoSealIntervalSeconds uint            `json:"autoSealIntervalSeconds"`
+	StoragePrice            *types.AttoFIL  `json:"storagePrice"`
 }
 
 func newDefaultMiningConfig() *MiningConfig {
 	return &MiningConfig{
 		MinerAddress:            address.Address{},
 		AutoSealIntervalSeconds: 120,
+		StoragePrice:            types.NewZeroAttoFIL(),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,7 +65,8 @@ func TestWriteFile(t *testing.T) {
 	},
 	"mining": {
 		"minerAddress": "",
-		"autoSealIntervalSeconds": 120
+		"autoSealIntervalSeconds": 120,
+		"storagePrice": "0"
 	},
 	"wallet": {
 		"defaultAddress": ""

--- a/porcelain/miner.go
+++ b/porcelain/miner.go
@@ -1,0 +1,80 @@
+package porcelain
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	minerActor "github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
+	vmErrors "github.com/filecoin-project/go-filecoin/vm/errors"
+)
+
+// mspPlumbing is the subset of the plumbing.API that MinerSetPrice uses.
+type mspPlumbing interface {
+	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
+	ConfigSet(dottedKey string, jsonString string) error
+	ConfigGet(dottedPath string) (interface{}, error)
+}
+
+// MinerSetPriceResponse collects relevant stats from the set price process
+type MinerSetPriceResponse struct {
+	Price     *types.AttoFIL
+	MinerAddr address.Address
+	AddAskCid cid.Cid
+	BlockCid  cid.Cid
+}
+
+// MinerSetPrice configures the price of storage, then sends an ask advertising that price and waits for it to be mined.
+// If minerAddr is empty, the default miner will be used.
+// This method is non-transactional in the sense that it will set the price whether or not it creates the ask successfully.
+func MinerSetPrice(ctx context.Context, plumbing mspPlumbing, from address.Address, miner address.Address, gasPrice types.AttoFIL, gasLimit types.GasUnits, price *types.AttoFIL, expiry *big.Int) (MinerSetPriceResponse, error) {
+	res := MinerSetPriceResponse{
+		Price: price,
+	}
+
+	// get miner address if not provided
+	if miner.Empty() {
+		minerValue, err := plumbing.ConfigGet("mining.minerAddress")
+		if err != nil {
+			return res, errors.Wrap(err, "Could not get miner address in config")
+		}
+		minerAddr, ok := minerValue.(address.Address)
+		if !ok {
+			return res, errors.Wrap(err, "Configured miner is not an address")
+		}
+		miner = minerAddr
+	}
+	res.MinerAddr = miner
+
+	// set price
+	jsonPrice, err := json.Marshal(price)
+	if err != nil {
+		return res, errors.New("Could not marshal price")
+	}
+	if err := plumbing.ConfigSet("mining.storagePrice", string(jsonPrice)); err != nil {
+		return res, err
+	}
+
+	// create ask
+	res.AddAskCid, err = plumbing.MessageSend(ctx, from, res.MinerAddr, types.NewZeroAttoFIL(), gasPrice, gasLimit, "addAsk", price, expiry)
+	if err != nil {
+		return res, errors.Wrap(err, "couldn't send message")
+	}
+
+	// wait for ask to be mined
+	err = plumbing.MessageWait(ctx, res.AddAskCid, func(blk *types.Block, smsg *types.SignedMessage, receipt *types.MessageReceipt) error {
+		res.BlockCid = blk.Cid()
+
+		if receipt.ExitCode != uint8(0) {
+			return vmErrors.VMExitCodeToError(receipt.ExitCode, minerActor.Errors)
+		}
+		return nil
+	})
+	return res, err
+}

--- a/porcelain/miner_test.go
+++ b/porcelain/miner_test.go
@@ -1,0 +1,260 @@
+package porcelain
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
+	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type minerTestPlumbing struct {
+	config  *cfg.Config
+	assert  *assert.Assertions
+	require *require.Assertions
+
+	msgCid   cid.Cid
+	blockCid cid.Cid
+
+	failGet  bool
+	failSet  bool
+	failSend bool
+	failWait bool
+
+	messageSend func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+}
+
+func newMinerTestPlumbing(assert *assert.Assertions, require *require.Assertions) *minerTestPlumbing {
+	return &minerTestPlumbing{
+		config:  cfg.NewConfig(repo.NewInMemoryRepo()),
+		assert:  assert,
+		require: require,
+	}
+}
+
+func (mtp *minerTestPlumbing) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+	if mtp.failSend {
+		return cid.Cid{}, errors.New("Test error in MessageSend")
+	}
+
+	if mtp.messageSend != nil {
+		cid, err := mtp.messageSend(ctx, from, to, value, gasPrice, gasLimit, method, params...)
+		mtp.msgCid = cid
+		return cid, err
+	}
+
+	mtp.msgCid = types.NewCidForTestGetter()()
+	return mtp.msgCid, nil
+}
+
+// calls back immediately
+func (mtp *minerTestPlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+	if mtp.failWait {
+		return errors.New("Test error in MessageWait")
+	}
+
+	mtp.require.True(msgCid.Equals(mtp.msgCid))
+
+	block := &types.Block{
+		Nonce: 393,
+	}
+	mtp.blockCid = block.Cid()
+
+	// call back
+	cb(block, &types.SignedMessage{}, &types.MessageReceipt{ExitCode: 0, Return: []types.Bytes{}})
+
+	return nil
+}
+
+func (mtp *minerTestPlumbing) ConfigSet(dottedKey string, jsonString string) error {
+	if mtp.failSet {
+		return errors.New("Test error in ConfigSet")
+	}
+
+	return mtp.config.Set(dottedKey, jsonString)
+}
+
+func (mtp *minerTestPlumbing) ConfigGet(dottedPath string) (interface{}, error) {
+	if mtp.failGet {
+		return nil, errors.New("Test error in ConfigGet")
+	}
+
+	return mtp.config.Get(dottedPath)
+}
+
+func TestMinerSetPrice(t *testing.T) {
+	t.Run("reports error when get miner address fails", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+		plumbing.failGet = true
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.Error(err)
+		assert.Contains(err.Error(), "Test error in ConfigGet")
+	})
+
+	t.Run("reports error when setting into config", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+		plumbing.failSet = true
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.Error(err)
+		assert.Contains(err.Error(), "Test error in ConfigSet")
+	})
+
+	t.Run("sets price into config", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.NoError(err)
+
+		configPrice, err := plumbing.config.Get("mining.storagePrice")
+		require.NoError(err)
+
+		assert.Equal(price, configPrice)
+	})
+
+	t.Run("saves config and reports error when send fails", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+		plumbing.failSend = true
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.Error(err)
+		assert.Contains(err.Error(), "Test error in MessageSend")
+
+		configPrice, err := plumbing.config.Get("mining.storagePrice")
+		require.NoError(err)
+
+		assert.Equal(price, configPrice)
+	})
+
+	t.Run("sends ask to specific miner when miner is given", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		minerAddr := address.NewForTestGetter()()
+
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+			assert.Equal(minerAddr, to)
+			return types.NewCidForTestGetter()(), nil
+		}
+
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, minerAddr, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.NoError(err)
+	})
+
+	t.Run("sends ask to default miner when no miner is given", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+
+		minerAddr := address.NewForTestGetter()()
+		require.NoError(plumbing.config.Set("mining.minerAddress", minerAddr.String()))
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+			assert.Equal(minerAddr, to)
+			return types.NewCidForTestGetter()(), nil
+		}
+
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.NoError(err)
+	})
+
+	t.Run("sends ask with correct parameters", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		expiry := big.NewInt(24)
+
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+			assert.Equal("addAsk", method)
+			assert.Equal(price, params[0])
+			assert.Equal(expiry, params[1])
+			return types.NewCidForTestGetter()(), nil
+		}
+
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, expiry)
+		require.NoError(err)
+	})
+
+	t.Run("reports error when wait fails", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+		plumbing.failWait = true
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+
+		_, err := MinerSetPrice(ctx, plumbing, address.Address{}, address.Address{}, types.NewGasPrice(0), types.NewGasUnits(0), price, big.NewInt(0))
+		require.Error(err)
+		assert.Contains(err.Error(), "Test error in MessageWait")
+	})
+
+	t.Run("returns interesting information about adding the ask", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newMinerTestPlumbing(assert, require)
+
+		ctx := context.Background()
+		price := types.NewAttoFILFromFIL(50)
+		expiry := big.NewInt(24)
+		minerAddr := address.NewForTestGetter()()
+
+		messageCid := types.NewCidForTestGetter()()
+
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+			return messageCid, nil
+		}
+
+		res, err := MinerSetPrice(ctx, plumbing, address.Address{}, minerAddr, types.NewGasPrice(0), types.NewGasUnits(0), price, expiry)
+		require.NoError(err)
+
+		assert.Equal(price, res.Price)
+		assert.Equal(minerAddr, res.MinerAddr)
+		assert.Equal(messageCid, res.AddAskCid)
+		assert.Equal(plumbing.blockCid, res.BlockCid)
+	})
+}

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -1,6 +1,10 @@
 package storage
 
 import (
+	"context"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/proofs/sectorbuilder"
@@ -10,6 +14,109 @@ import (
 	"github.com/stretchr/testify/require"
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 )
+
+type minerTestPlumbing struct {
+	config *cfg.Config
+}
+
+func newMinerTestPlumbing() *minerTestPlumbing {
+	return &minerTestPlumbing{
+		config: cfg.NewConfig(repo.NewInMemoryRepo()),
+	}
+}
+
+func (mtp *minerTestPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
+	return [][]byte{}, nil, nil
+}
+
+func (mtp *minerTestPlumbing) ActorGetSignature(ctx context.Context, actorAddr address.Address, method string) (*exec.FunctionSignature, error) {
+	return nil, nil
+}
+
+func (mtp *minerTestPlumbing) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+	return cid.Cid{}, nil
+}
+
+// calls back immediately
+func (mtp *minerTestPlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+	return nil
+}
+
+func (mtp *minerTestPlumbing) ConfigGet(dottedPath string) (interface{}, error) {
+	return mtp.config.Get(dottedPath)
+}
+
+func TestReceiveStorageProposal(t *testing.T) {
+	t.Run("Accepts proposals with sufficient TotalPrice", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		accepted := false
+		rejected := false
+
+		plumbingAPI := newMinerTestPlumbing()
+		miner := Miner{
+			plumbingAPI: plumbingAPI,
+			proposalAcceptor: func(ctx context.Context, m *Miner, p *DealProposal) (*DealResponse, error) {
+				accepted = true
+				return &DealResponse{}, nil
+			},
+			proposalRejector: func(ctx context.Context, m *Miner, p *DealProposal, reason string) (*DealResponse, error) {
+				rejected = true
+				return &DealResponse{Message: reason}, nil
+			},
+		}
+
+		// configure storage price
+		plumbingAPI.config.Set("mining.storagePrice", `"50"`)
+
+		proposal := &DealProposal{
+			TotalPrice: types.NewAttoFILFromFIL(75),
+		}
+
+		_, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.True(accepted, "Proposal has been accepted")
+		assert.False(rejected, "Proposal has not been rejected")
+	})
+
+	t.Run("Rejects proposals with insufficient TotalPrice", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		accepted := false
+		rejected := false
+
+		plumbingAPI := newMinerTestPlumbing()
+		miner := Miner{
+			plumbingAPI: plumbingAPI,
+			proposalAcceptor: func(ctx context.Context, m *Miner, p *DealProposal) (*DealResponse, error) {
+				accepted = true
+				return &DealResponse{}, nil
+			},
+			proposalRejector: func(ctx context.Context, m *Miner, p *DealProposal, reason string) (*DealResponse, error) {
+				rejected = true
+				return &DealResponse{Message: reason}, nil
+			},
+		}
+
+		// configure storage price
+		plumbingAPI.config.Set("mining.storagePrice", `"50"`)
+
+		proposal := &DealProposal{
+			TotalPrice: types.NewAttoFILFromFIL(25),
+		}
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.False(accepted, "Proposal has not been accepted")
+		assert.True(rejected, "Proposal has been rejected")
+
+		assert.Equal("proposed price 25 is less that miner's current asking price: 50", res.Message)
+	})
+}
 
 func TestDealsAwaitingSeal(t *testing.T) {
 	newCid := types.NewCidForTestGetter()

--- a/repo/fsrepo_test.go
+++ b/repo/fsrepo_test.go
@@ -46,7 +46,8 @@ const (
 	},
 	"mining": {
 		"minerAddress": "",
-		"autoSealIntervalSeconds": 120
+		"autoSealIntervalSeconds": 120,
+		"storagePrice": "0"
 	},
 	"wallet": {
 		"defaultAddress": ""


### PR DESCRIPTION
closes #1428

# Problem

Miners need to get paid. As we automate the process of accepting deal proposals, we need to make sure miners automatically reject proposals with an insufficient price. There are a couple aspects to this:

1. While asks will still be placed on chain (for now), they should not longer represent the price of record. Miners should store the price in their repo.
2. Miners should automatically reject proposals whose total price is less that their stored price.

# Solution

In this PR we introduce a new `miner set-price` that both sets a mining.storagePrice in config, and sends an ask for that price. In the `Miner` part of the storage we introduce logic to reject storage proposals that are below the configured price.

# Things to look out for

* This story introduces a Mining.StroragePrice field to config. This will be a breaking change.* `miner set-price` calls a new `MinerSetPrice` porcelain API call. This is the second porcelain call and it mostly reinforces the patterns established by `MessageSendWithRetry` with some small tweaks for testing.
* `storage/Miner` has been refactored to make it somewhat mockable for testing. This is only a first step. A lot more work could be done here as it has several long chains of method calls with network functionality interleaved.
* `miner set-price` has a single happy path daemon test.

# After Merge

All docs and cluster scripts need to be updated to replace `add-ask` commands with `set-price`.