### PR TITLE
Set valid gas limit (300) for all on chain messages.

### DIFF
--- a/commands/address_daemon_test.go
+++ b/commands/address_daemon_test.go
@@ -77,7 +77,7 @@ func TestAddrLookupAndUpdate(t *testing.T) {
 		"miner", "update-peerid",
 		"--from", addr,
 		"--price", "0",
-		"--limit", "100",
+		"--limit", "300",
 		minerAddr,
 		minerPidForUpdate.Pretty(),
 	)

--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -28,7 +28,7 @@ func TestMessageSend(t *testing.T) {
 		"invalid checksum",
 		"message", "send",
 		"--from", fixtures.TestAddresses[0],
-		"--price", "0", "--limit", "0",
+		"--price", "0", "--limit", "300",
 		"--value=10", "xyz",
 	)
 
@@ -36,14 +36,14 @@ func TestMessageSend(t *testing.T) {
 	defaultaddr := d.GetDefaultAddress()
 	d.RunSuccess("message", "send",
 		"--from", fixtures.TestAddresses[0],
-		"--price", "0", "--limit", "0",
+		"--price", "0", "--limit", "300",
 		defaultaddr,
 	)
 
 	t.Log("[success] with from and value")
 	d.RunSuccess("message", "send",
 		"--from", fixtures.TestAddresses[0],
-		"--price", "0", "--limit", "0",
+		"--price", "0", "--limit", "300",
 		"--value=10", fixtures.TestAddresses[1],
 	)
 }
@@ -64,7 +64,7 @@ func TestMessageWait(t *testing.T) {
 		msg := d.RunSuccess(
 			"message", "send",
 			"--from", fixtures.TestAddresses[0],
-			"--price", "0", "--limit", "0",
+			"--price", "0", "--limit", "300",
 			"--value=10",
 			fixtures.TestAddresses[1],
 		)

--- a/commands/mpool_daemon_test.go
+++ b/commands/mpool_daemon_test.go
@@ -25,7 +25,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
-			"--price", "0", "--limit", "0",
+			"--price", "0", "--limit", "300",
 			"--value=10", fixtures.TestAddresses[2],
 		)
 
@@ -55,7 +55,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
-			"--price", "0", "--limit", "0",
+			"--price", "0", "--limit", "300",
 			"--value=10", fixtures.TestAddresses[1],
 		)
 
@@ -63,7 +63,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
-			"--price", "0", "--limit", "0",
+			"--price", "0", "--limit", "300",
 			"--value=10", fixtures.TestAddresses[1],
 		)
 
@@ -71,7 +71,7 @@ func TestMpool(t *testing.T) {
 
 		d.RunSuccess("message", "send",
 			"--from", fixtures.TestAddresses[0],
-			"--price", "0", "--limit", "0",
+			"--price", "0", "--limit", "300",
 			"--value=10", fixtures.TestAddresses[1],
 		)
 

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -467,7 +467,7 @@ func (td *TestDaemon) CreateMinerAddr(peer *TestDaemon, fromAddr string) address
 	var minerAddr address.Address
 	wg.Add(1)
 	go func() {
-		miner := td.RunSuccess("miner", "create", "--from", fromAddr, "--price", "0", "--limit", "100", "100", "20")
+		miner := td.RunSuccess("miner", "create", "--from", fromAddr, "--price", "0", "--limit", "300", "100", "20")
 		addr, err := address.NewFromString(strings.Trim(miner.ReadStdout(), "\n"))
 		require.NoError(err)
 		require.NotEqual(addr, address.Address{})
@@ -497,7 +497,7 @@ func (td *TestDaemon) UpdatePeerID() {
 	peerIDJSON := td.RunSuccess("id").ReadStdout()
 	err := json.Unmarshal([]byte(peerIDJSON), &idOutput)
 	require.NoError(err)
-	updateCidStr := td.RunSuccess("miner", "update-peerid", "--price=0", "--limit=999999", td.GetMinerAddress().String(), idOutput["ID"].(string)).ReadStdoutTrimNewlines()
+	updateCidStr := td.RunSuccess("miner", "update-peerid", "--price=0", "--limit=300", td.GetMinerAddress().String(), idOutput["ID"].(string)).ReadStdoutTrimNewlines()
 	updateCid, err := cid.Parse(updateCidStr)
 	require.NoError(err)
 	assert.NotNil(updateCid)

--- a/testhelpers/iptbtester/genesis.go
+++ b/testhelpers/iptbtester/genesis.go
@@ -91,7 +91,7 @@ func MustImportGenesisMiner(tn *TestNode, gi *GenesisInfo) {
 	tn.MustRunCmdJSON(ctx, &id, "go-filecoin", "id")
 
 	// Update miner
-	tn.MustRunCmd(ctx, "go-filecoin", "miner", "update-peerid", "--from="+gi.WalletAddress, "--price=0", "--limit=0", gi.MinerAddress, id.ID)
+	tn.MustRunCmd(ctx, "go-filecoin", "miner", "update-peerid", "--from="+gi.WalletAddress, "--price=0", "--limit=300", gi.MinerAddress, id.ID)
 }
 
 // MustInitWithGenesis init TestNode, passing in the `--genesisfile` flag, by calling MustInit

--- a/tools/iptb-plugins/filecoin/local/scripts/prepMining.sh
+++ b/tools/iptb-plugins/filecoin/local/scripts/prepMining.sh
@@ -48,7 +48,7 @@ ownerRaw=$(iptb run 0 -- go-filecoin wallet import "$FIXDIR/0.key")
 minerOwner=$(echo $ownerRaw | sed -e 's/^node\[0\] exit 0 //' | jq -r ".")
 # update the peerID to the correct value
 peerID=$(iptb run 0 -- go-filecoin id | tail -n +3 | jq ".ID" -r)
-iptb run 0 -- go-filecoin miner update-peerid --from="$minerOwner" --price=0 --limit=0 "$minerAddr" "$peerID"
+iptb run 0 -- go-filecoin miner update-peerid --from="$minerOwner" --price=0 --limit=300 "$minerAddr" "$peerID"
 # start mining
 iptb run 0 -- go-filecoin mining start
 
@@ -86,7 +86,7 @@ do
 
     # add an ask
     printf "adding ask"
-    iptb run "$i" -- go-filecoin miner add-ask "$newMinerAddr" 1 100000 --price=0 --limit=0 # price of one FIL/whatever, ask is valid for 100000 blocks
+    iptb run "$i" -- go-filecoin miner add-ask "$newMinerAddr" 1 100000 --price=0 --limit=300 # price of one FIL/whatever, ask is valid for 100000 blocks
 
     # make a deal
     dd if=/dev/random of="$FIXDIR/fake.dat"  bs="$DD_FILE_SIZE"  count=1 # small data file will be autosealed


### PR DESCRIPTION
Closes #1685

### Problem

With the addition of actual gas charging, many existing processes within the app and its documentation now have a gas limit that is low enough that it is exceed by the message processing.

### Solution

300 is a safe limit for now. Change all known messages with limits to be 300 in code and documentation.