### PR TITLE
No Error Log Entries for PoST Faults

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -19,7 +19,7 @@ func TestListAsks(t *testing.T) {
 		th.KeyFile(fixtures.KeyFilePaths()[0]),
 		th.DefaultAddress(fixtures.TestAddresses[0]),
 	).Start()
-	defer minerDaemon.Shutdown()
+	defer minerDaemon.ShutdownSuccess()
 
 	minerDaemon.RunSuccess("mining start")
 	minerDaemon.CreateAsk(fixtures.TestMiners[0], fixtures.TestAddresses[0], "20", "10")
@@ -36,7 +36,7 @@ func TestStorageDealsAfterRestart(t *testing.T) {
 		th.DefaultAddress(fixtures.TestAddresses[0]),
 		th.AutoSealInterval("1"),
 	).Start()
-	defer minerDaemon.Shutdown()
+	defer minerDaemon.ShutdownSuccess()
 
 	clientDaemon := th.NewDaemon(t,
 		th.KeyFile(fixtures.KeyFilePaths()[1]),
@@ -77,7 +77,7 @@ func TestDuplicateDeals(t *testing.T) {
 		th.KeyFile(fixtures.KeyFilePaths()[0]),
 		th.DefaultAddress(fixtures.TestAddresses[0]),
 	).Start()
-	defer miner.Shutdown()
+	defer miner.ShutdownSuccess()
 
 	client := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[2]), th.DefaultAddress(fixtures.TestAddresses[2])).Start()
 	defer client.ShutdownSuccess()
@@ -113,13 +113,13 @@ func TestDealWithSameDataAndDifferentMiners(t *testing.T) {
 		th.KeyFile(fixtures.KeyFilePaths()[0]),
 		th.DefaultAddress(fixtures.TestAddresses[0]),
 	).Start()
-	defer miner1.Shutdown()
+	defer miner1.ShutdownSuccess()
 
 	miner2 := th.NewDaemon(t,
 		th.KeyFile(fixtures.KeyFilePaths()[1]),
 		th.DefaultAddress(fixtures.TestAddresses[1]),
 	).Start()
-	defer miner2.Shutdown()
+	defer miner2.ShutdownSuccess()
 
 	client := th.NewDaemon(t, th.KeyFile(fixtures.KeyFilePaths()[2]), th.DefaultAddress(fixtures.TestAddresses[2])).Start()
 	defer client.ShutdownSuccess()

--- a/commands/miner_daemon_test.go
+++ b/commands/miner_daemon_test.go
@@ -293,7 +293,7 @@ func TestMinerSetPrice(t *testing.T) {
 	assert := assert.New(t)
 
 	d1 := th.NewDaemon(t, th.WithMiner(fixtures.TestMiners[0]), th.KeyFile(fixtures.KeyFilePaths()[0]), th.DefaultAddress(fixtures.TestAddresses[0])).Start()
-	defer d1.Shutdown()
+	defer d1.ShutdownSuccess()
 
 	d1.RunSuccess("mining", "start")
 

--- a/gengen/util/gengen_test.go
+++ b/gengen/util/gengen_test.go
@@ -42,7 +42,7 @@ func TestGenGenLoading(t *testing.T) {
 	assert.NoError(fi.Close())
 
 	td := th.NewDaemon(t, th.GenesisFile(fi.Name())).Start()
-	defer td.Shutdown()
+	defer td.ShutdownSuccess()
 
 	o := td.Run("actor", "ls").AssertSuccess()
 

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -607,7 +607,7 @@ func (sm *Miner) submitPoSt(start, end *types.BlockHeight, inputs []generatePost
 		return
 	}
 	if len(faults) != 0 {
-		log.Errorf("some faults when generating PoSt: %v", faults)
+		log.Warningf("some faults when generating PoSt: %v", faults)
 		// TODO: proper fault handling
 	}
 


### PR DESCRIPTION
We log PoST faults as `WARNING`s instead of `ERROR`s in the code, as these are (usually) not worthy of a developer's attention.

We replace usages of `Shutdown` in the test suite with `ShutdownSuccess`, since the above `ERROR` logging prevented properly functioning tests from using `ShutdownSuccess`.

Resolves #1642 
