### PR TITLE
Limit gas costs in block

### DIFF
--- a/actor/actor_test.go
+++ b/actor/actor_test.go
@@ -107,7 +107,7 @@ func NewMockActor(list exec.Exports) *MockActor {
 
 func makeCtx(method string) exec.VMContext {
 	addrGetter := address.NewForTestGetter()
-	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+	return vm.NewVMContext(nil, nil, types.NewMessage(addrGetter(), addrGetter(), 0, nil, method, nil), nil, nil, vm.NewGasTracker(), types.NewBlockHeight(0))
 }
 
 func TestMakeTypedExportSuccess(t *testing.T) {

--- a/actor/testing.go
+++ b/actor/testing.go
@@ -70,6 +70,10 @@ var FakeActorExports = exec.Exports{
 		Params: []abi.Type{abi.Address},
 		Return: nil,
 	},
+	"blockLimitTestMethod": &exec.FunctionSignature{
+		Params: nil,
+		Return: nil,
+	},
 }
 
 // InitializeState stores this actors
@@ -202,6 +206,15 @@ func (ma *FakeActor) RunsAnotherMessage(ctx exec.VMContext, target address.Addre
 	}
 	_, code, err := ctx.Send(target, "hasReturnValue", types.ZeroAttoFIL, []interface{}{})
 	return code, err
+}
+
+// BlockLimitTestMethod is designed to be used with block gas limit tests. It consumes 1/4 of the
+// block gas limit per run. Please ensure message.gasLimit >= 1/4 of block limit or it will panic.
+func (ma *FakeActor) BlockLimitTestMethod(ctx exec.VMContext) (uint8, error) {
+	if err := ctx.Charge(types.BlockGasLimit / 4); err != nil {
+		panic("designed for block limit testing, ensure msg limit is adequate")
+	}
+	return 0, nil
 }
 
 // MustConvertParams encodes the given params and panics if it fails to do so.

--- a/commands/message_daemon_test.go
+++ b/commands/message_daemon_test.go
@@ -1,13 +1,18 @@
 package commands
 
 import (
+	"encoding/json"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/filecoin-project/go-filecoin/fixtures"
 	th "github.com/filecoin-project/go-filecoin/testhelpers"
-	"github.com/stretchr/testify/assert"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 func TestMessageSend(t *testing.T) {
@@ -89,5 +94,51 @@ func TestMessageWait(t *testing.T) {
 		d.RunSuccess("mining once")
 
 		wg.Wait()
+	})
+}
+
+func TestMessageSendBlockGasLimit(t *testing.T) {
+	t.Parallel()
+
+	d := th.NewDaemon(
+		t,
+		th.DefaultAddress(fixtures.TestAddresses[0]),
+		th.WithMiner(fixtures.TestMiners[0]),
+		th.KeyFile(fixtures.KeyFilePaths()[0]),
+	).Start()
+	defer d.ShutdownSuccess()
+
+	doubleTheBlockGasLimit := strconv.Itoa(int(types.BlockGasLimit) * 2)
+	halfTheBlockGasLimit := strconv.Itoa(int(types.BlockGasLimit) / 2)
+	result := struct{ Messages []interface{} }{}
+
+	t.Run("when the gas limit is above the block limit, the message fails", func(t *testing.T) {
+		d.RunSuccess(
+			"message", "send",
+			"--price", "0", "--limit", doubleTheBlockGasLimit,
+			"--value=10", fixtures.TestAddresses[1],
+		)
+
+		blockCid := d.RunSuccess("mining", "once").ReadStdoutTrimNewlines()
+
+		blockInfo := d.RunSuccess("show", "block", blockCid, "--enc", "json").ReadStdoutTrimNewlines()
+
+		require.NoError(t, json.Unmarshal([]byte(blockInfo), &result))
+		assert.Empty(t, result.Messages, "msg over the block gas limit fails validation and is _NOT_ run in the block")
+	})
+
+	t.Run("when the gas limit is below the block limit, the message succeeds", func(t *testing.T) {
+		d.RunSuccess(
+			"message", "send",
+			"--price", "0", "--limit", halfTheBlockGasLimit,
+			"--value=10", fixtures.TestAddresses[1],
+		)
+
+		blockCid := d.RunSuccess("mining", "once").ReadStdoutTrimNewlines()
+
+		blockInfo := d.RunSuccess("show", "block", blockCid, "--enc", "json").ReadStdoutTrimNewlines()
+
+		require.NoError(t, json.Unmarshal([]byte(blockInfo), &result))
+		assert.NotEmpty(t, result.Messages, "msg under the block gas limit passes validation and is run in the block")
 	})
 }

--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -14,10 +14,10 @@ import (
 )
 
 // SignedMessageValidator validates incoming signed messages.
-// This validation includes things like the message signature, it's nonce, that it comes from a valid actor, etc.
+// This also includes other validations limited to the scope of the message and its fromActor
 type SignedMessageValidator interface {
 	// Validate validates that the given message is ready to be processed.
-	Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor, bh *types.BlockHeight) error
+	Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error
 }
 
 // BlockRewarder applies all rewards due to the miner for processing a block including block reward and gas
@@ -39,7 +39,7 @@ type ApplicationResult struct {
 
 // ProcessTipSetResponse records the results of successfully applied messages,
 // and the sets of successful and failed message cids.  Information of successes
-// and failues is key for helping match user messages with receipts in the case
+// and failures is key for helping match user messages with receipts in the case
 // of message conflicts.
 type ProcessTipSetResponse struct {
 	Results   []*ApplicationResult
@@ -261,10 +261,10 @@ func (p *DefaultProcessor) ProcessTipSet(ctx context.Context, st state.Tree, vms
 //   - ApplyMessage and VMContext.Send() are the only things that should call
 //     Send() -- all the user-actor logic goes in ApplyMessage and all the
 //     actor-actor logic goes in VMContext.Send.
-func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.SignedMessage, minerAddr address.Address, bh *types.BlockHeight) (*ApplicationResult, error) {
+func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms vm.StorageMap, msg *types.SignedMessage, minerAddr address.Address, bh *types.BlockHeight, gasTracker *vm.GasTracker) (*ApplicationResult, error) {
 	cachedStateTree := state.NewCachedStateTree(st)
 
-	r, err := p.attemptApplyMessage(ctx, cachedStateTree, vms, msg, bh)
+	r, err := p.attemptApplyMessage(ctx, cachedStateTree, vms, msg, bh, gasTracker)
 	if err == nil {
 		err = cachedStateTree.Commit(ctx)
 		if err != nil {
@@ -285,9 +285,9 @@ func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms 
 
 	// Reject invalid state transitions.
 	var executionError error
-	if err == errFromAccountNotFound || err == errNonceTooHigh {
+	if isTemporaryError(err) {
 		return nil, errors.ApplyErrorTemporaryWrapf(err, "apply message failed")
-	} else if err == errInsufficientGas || err == errSelfSend || err == errInvalidSignature || err == errNonceTooLow || err == errNonAccountActor || err == errors.Errors[errors.ErrCannotTransferNegativeValue] {
+	} else if isPermanentError(err) {
 		return nil, errors.ApplyErrorPermanentWrapf(err, "apply message failed")
 	} else if err != nil { // nolint: staticcheck
 		// Return the executionError to caller for informational purposes, but otherwise
@@ -316,12 +316,14 @@ func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms 
 var (
 	// These errors are only to be used by ApplyMessage; they shouldn't be
 	// used in any other context as they are an implementation detail.
-	errFromAccountNotFound = errors.NewRevertError("from (sender) account not found")
-	errNonceTooHigh        = errors.NewRevertError("nonce too high")
-	errNonceTooLow         = errors.NewRevertError("nonce too low")
-	errNonAccountActor     = errors.NewRevertError("message from non-account actor")
-	errInsufficientGas     = errors.NewRevertError("balance insufficient to cover transfer+gas")
-	errInvalidSignature    = errors.NewRevertError("invalid signature by sender over message data")
+	errFromAccountNotFound       = errors.NewRevertError("from (sender) account not found")
+	errGasAboveBlockLimit        = errors.NewRevertError("message gas limit above block gas limit")
+	errGasTooHighForCurrentBlock = errors.NewRevertError("message gas limit too high for current block")
+	errNonceTooHigh              = errors.NewRevertError("nonce too high")
+	errNonceTooLow               = errors.NewRevertError("nonce too low")
+	errNonAccountActor           = errors.NewRevertError("message from non-account actor")
+	errInsufficientGas           = errors.NewRevertError("balance insufficient to cover transfer+gas")
+	errInvalidSignature          = errors.NewRevertError("invalid signature by sender over message data")
 	// TODO we'll eventually handle sending to self.
 	errSelfSend = errors.NewRevertError("cannot send to self")
 )
@@ -348,9 +350,10 @@ func CallQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to a
 	}
 
 	// Set the gas limit to the max because this message send should always succeed; it doesn't cost gas.
-	gasLimit := types.NewGasUnits(types.MaxGasUnits)
+	gasTracker := vm.NewGasTracker()
+	gasTracker.MsgGasLimit = types.BlockGasLimit
 
-	vmCtx := vm.NewVMContext(nil, toActor, msg, cachedSt, vms, types.NewGasPrice(0), gasLimit, types.NewGasUnits(0), optBh)
+	vmCtx := vm.NewVMContext(nil, toActor, msg, cachedSt, vms, gasTracker, optBh)
 	ret, retCode, err := vm.Send(ctx, vmCtx)
 
 	return ret, retCode, err
@@ -361,7 +364,15 @@ func CallQueryMethod(ctx context.Context, st state.Tree, vms vm.StorageMap, to a
 // should deal with trying to apply the message to the state tree whereas
 // ApplyMessage should deal with any side effects and how it should be presented
 // to the caller. attemptApplyMessage should only be called from ApplyMessage.
-func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.CachedTree, store vm.StorageMap, msg *types.SignedMessage, bh *types.BlockHeight) (*types.MessageReceipt, error) {
+func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.CachedTree, store vm.StorageMap, msg *types.SignedMessage, bh *types.BlockHeight, gasTracker *vm.GasTracker) (*types.MessageReceipt, error) {
+	gasTracker.ResetForNewMessage(msg.MeteredMessage)
+	if err := blockGasLimitError(gasTracker); err != nil {
+		return &types.MessageReceipt{
+			ExitCode:   errors.CodeError(err),
+			GasAttoFIL: types.ZeroAttoFIL,
+		}, err
+	}
+
 	fromActor, err := st.GetActor(ctx, msg.From)
 	if state.IsActorNotFoundError(err) {
 		return &types.MessageReceipt{
@@ -380,7 +391,7 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		}
 	}
 
-	err = p.signedMessageValidator.Validate(ctx, msg, fromActor, bh)
+	err = p.signedMessageValidator.Validate(ctx, msg, fromActor)
 	if err != nil {
 		return &types.MessageReceipt{
 			ExitCode:   errors.CodeError(err),
@@ -398,7 +409,7 @@ func (p *DefaultProcessor) attemptApplyMessage(ctx context.Context, st *state.Ca
 		return nil, errors.FaultErrorWrap(err, "failed to get To actor")
 	}
 
-	vmCtx := vm.NewVMContext(fromActor, toActor, &msg.Message, st, store, msg.GasPrice, msg.GasLimit, types.NewGasUnits(0), bh)
+	vmCtx := vm.NewVMContext(fromActor, toActor, &msg.Message, st, store, gasTracker, bh)
 	ret, exitCode, vmErr := vm.Send(ctx, vmCtx)
 	if errors.IsFault(vmErr) {
 		return nil, vmErr
@@ -449,9 +460,11 @@ func (p *DefaultProcessor) ApplyMessagesAndPayRewards(ctx context.Context, st st
 		return ApplyMessagesResponse{}, err
 	}
 
+	gasTracker := vm.NewGasTracker()
+
 	// process all messages
 	for _, smsg := range messages {
-		r, err := p.ApplyMessage(ctx, st, vms, smsg, minerAddr, bh)
+		r, err := p.ApplyMessage(ctx, st, vms, smsg, minerAddr, bh, gasTracker)
 		// If the message should not have been in the block, bail somehow.
 		switch {
 		case errors.IsFault(err):
@@ -459,11 +472,9 @@ func (p *DefaultProcessor) ApplyMessagesAndPayRewards(ctx context.Context, st st
 		case errors.IsApplyErrorPermanent(err):
 			ret.PermanentFailures = append(ret.PermanentFailures, smsg)
 			ret.PermanentErrors = append(ret.PermanentErrors, err)
-			continue
 		case errors.IsApplyErrorTemporary(err):
 			ret.TemporaryFailures = append(ret.TemporaryFailures, smsg)
 			ret.TemporaryErrors = append(ret.TemporaryErrors, err)
-			continue
 		case err != nil:
 			panic("someone is a bad programmer: error is neither fault, perm or temp")
 		default:
@@ -485,13 +496,12 @@ func NewDefaultMessageValidator() *DefaultMessageValidator {
 var _ SignedMessageValidator = (*DefaultMessageValidator)(nil)
 
 // Validate validates that the given message is ready to be processed.
-func (nmv *DefaultMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor, bh *types.BlockHeight) error {
+func (nmv *DefaultMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
 	if !msg.VerifySignature() {
 		return errInvalidSignature
 	}
 
 	if msg.From == msg.To {
-		// TODO: handle this
 		return errSelfSend
 	}
 
@@ -575,4 +585,29 @@ func rewardTransfer(ctx context.Context, fromAddr, toAddr address.Address, value
 func canCoverGasLimit(msg *types.SignedMessage, actor *actor.Actor) bool {
 	maximumGasCharge := msg.GasPrice.MulBigInt(big.NewInt(int64(msg.GasLimit)))
 	return maximumGasCharge.LessEqual(actor.Balance.Sub(msg.Value))
+}
+
+func blockGasLimitError(gasTracker *vm.GasTracker) error {
+	if gasTracker.GasAboveBlockLimit() {
+		return errGasAboveBlockLimit
+	} else if gasTracker.GasTooHighForCurrentBlock() {
+		return errGasTooHighForCurrentBlock
+	}
+	return nil
+}
+
+func isTemporaryError(err error) bool {
+	return err == errFromAccountNotFound ||
+		err == errNonceTooHigh ||
+		err == errGasTooHighForCurrentBlock
+}
+
+func isPermanentError(err error) bool {
+	return err == errInsufficientGas ||
+		err == errSelfSend ||
+		err == errInvalidSignature ||
+		err == errNonceTooLow ||
+		err == errNonAccountActor ||
+		err == errors.Errors[errors.ErrCannotTransferNegativeValue] ||
+		err == errGasAboveBlockLimit
 }

--- a/consensus/processor_test.go
+++ b/consensus/processor_test.go
@@ -438,7 +438,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 		require.NoError(err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0))
+		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker())
 		assert.Error(err)
 		assert.Equal("nonce too high", err.(*errors.ApplyErrorTemporary).Cause().Error())
 	})
@@ -466,7 +466,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 		require.NoError(err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0))
+		_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker())
 		assert.Error(err)
 		assert.Equal("nonce too low", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -481,7 +481,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.NoError(err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0))
+		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker())
 		require.Error(err)
 		assert.Equal("balance insufficient to cover transfer+gas", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -502,7 +502,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		smsg, err := types.NewSignedMessage(*msg, mockSigner, *types.NewAttoFILFromFIL(10), types.NewGasUnits(50))
 		require.NoError(err)
 
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0))
+		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker())
 		require.Error(err)
 		assert.Equal("message from non-account actor", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -517,7 +517,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.NoError(err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0))
+		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, addr2, types.NewBlockHeight(0), vm.NewGasTracker())
 		require.Error(err)
 		assert.Equal("cannot send to self", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -532,7 +532,7 @@ func TestApplyMessagesValidation(t *testing.T) {
 		require.NoError(err)
 
 		// the maximum gas charge (10*50 = 500) is greater than the sender balance minus the message value (1000-550 = 450)
-		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, address.Address{}, types.NewBlockHeight(0))
+		_, err = NewDefaultProcessor().ApplyMessage(context.Background(), st, th.VMStorage(), smsg, address.Address{}, types.NewBlockHeight(0), vm.NewGasTracker())
 		require.Error(err)
 		assert.Equal("balance insufficient to cover transfer+gas", err.(*errors.ApplyErrorPermanent).Cause().Error())
 	})
@@ -658,14 +658,14 @@ func TestSendToNonexistentAddressThenSpendFromIt(t *testing.T) {
 	msg := types.NewMessage(addr1, addr2, 0, types.NewAttoFILFromFIL(500), "", []byte{})
 	smsg, err := types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
-	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr4, types.NewBlockHeight(0))
+	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr4, types.NewBlockHeight(0), vm.NewGasTracker())
 	require.NoError(err)
 
 	// send 250 along from addr2 to addr3
 	msg = types.NewMessage(addr2, addr3, 0, types.NewAttoFILFromFIL(300), "", []byte{})
 	smsg, err = types.NewSignedMessage(*msg, mockSigner, types.NewGasPrice(0), types.NewGasUnits(0))
 	require.NoError(err)
-	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr4, types.NewBlockHeight(0))
+	_, err = NewDefaultProcessor().ApplyMessage(ctx, st, th.VMStorage(), smsg, addr4, types.NewBlockHeight(0), vm.NewGasTracker())
 	require.NoError(err)
 
 	// get all 3 actors
@@ -883,17 +883,92 @@ func TestApplyMessageChargesGas(t *testing.T) {
 	})
 }
 
+func TestBlockGasLimitBehavior(t *testing.T) {
+	fakeActorCodeCid := types.NewCidForTestGetter()()
+	builtin.Actors[fakeActorCodeCid] = &actor.FakeActor{}
+	defer delete(builtin.Actors, fakeActorCodeCid)
+
+	actors, stateTree, signer := setupActorsForGasTest(t, th.VMStorage(), fakeActorCodeCid, 0)
+	sender := actors[1]
+	receiver := actors[2]
+	processor := NewTestProcessor()
+	ctx := context.Background()
+
+	t.Run("A single message whose gas limit is greater than the block gas limit fails permanently", func(t *testing.T) {
+		msg := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg, err := types.NewSignedMessage(*msg, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*2)
+		require.NoError(t, err)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg}, sender, types.NewBlockHeight(0))
+		require.NoError(t, err)
+
+		assert.Contains(t, result.PermanentFailures, sgnedMsg)
+	})
+
+	t.Run("2 msgs both succeed when sum of limits > block limit, but 1st usage + 2nd limit < block limit", func(t *testing.T) {
+		msg1 := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
+		require.NoError(t, err)
+
+		msg2 := types.NewMessage(sender, receiver, 1, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*5/8)
+		require.NoError(t, err)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0))
+		require.NoError(t, err)
+
+		assert.Contains(t, result.SuccessfulMessages, sgnedMsg1)
+		assert.Contains(t, result.SuccessfulMessages, sgnedMsg2)
+	})
+
+	t.Run("2nd message delayed when 1st usage + 2nd limit > block limit", func(t *testing.T) {
+		msg1 := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		require.NoError(t, err)
+
+		msg2 := types.NewMessage(sender, receiver, 1, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
+		require.NoError(t, err)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2}, sender, types.NewBlockHeight(0))
+		require.NoError(t, err)
+
+		assert.Contains(t, result.SuccessfulMessages, sgnedMsg1)
+		assert.Contains(t, result.TemporaryFailures, sgnedMsg2)
+	})
+
+	t.Run("message with high gas limit does not block messages with lower limits from being included in block", func(t *testing.T) {
+		msg1 := types.NewMessage(sender, receiver, 0, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg1, err := types.NewSignedMessage(*msg1, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		require.NoError(t, err)
+
+		msg2 := types.NewMessage(sender, receiver, 1, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg2, err := types.NewSignedMessage(*msg2, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*7/8)
+		require.NoError(t, err)
+
+		msg3 := types.NewMessage(sender, receiver, 2, nil, "blockLimitTestMethod", []byte{})
+		sgnedMsg3, err := types.NewSignedMessage(*msg3, signer, *types.NewZeroAttoFIL(), types.BlockGasLimit*3/8)
+		require.NoError(t, err)
+
+		result, err := processor.ApplyMessagesAndPayRewards(ctx, stateTree, th.VMStorage(), []*types.SignedMessage{sgnedMsg1, sgnedMsg2, sgnedMsg3}, sender, types.NewBlockHeight(0))
+		require.NoError(t, err)
+
+		assert.Contains(t, result.SuccessfulMessages, sgnedMsg1, sgnedMsg3)
+		assert.Contains(t, result.TemporaryFailures, sgnedMsg2)
+	})
+}
+
 func setupActorsForGasTest(t *testing.T, vms vm.StorageMap, fakeActorCodeCid cid.Cid, senderBalance uint64) ([]address.Address, state.Tree, *types.MockSigner) {
 	require := require.New(t)
 
 	addressGenerator := address.NewForTestGetter()
 
-	keyInfo := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())
+	keyInfo := types.MustGenerateKeyInfo(3, types.GenerateKeyInfoSeed())
 	mockSigner := types.NewMockSigner(keyInfo)
 	addresses := []address.Address{
 		mockSigner.Addresses[0], // addr0
-		addressGenerator(),      // addr1
-		addressGenerator(),      // addr2
+		mockSigner.Addresses[1], // addr1
+		mockSigner.Addresses[2], // addr2
 		addressGenerator()}      // minerAddr
 
 	var actors []*actor.Actor

--- a/consensus/testing.go
+++ b/consensus/testing.go
@@ -78,7 +78,7 @@ type TestSignedMessageValidator struct{}
 var _ SignedMessageValidator = (*TestSignedMessageValidator)(nil)
 
 // Validate always returns nil
-func (tsmv *TestSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor, bh *types.BlockHeight) error {
+func (tsmv *TestSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
 	return nil
 }
 
@@ -100,7 +100,7 @@ func (tbr *TestBlockRewarder) GasReward(ctx context.Context, st state.Tree, mine
 }
 
 // NewTestProcessor creates a processor with a test validator and test rewarder
-func NewTestProcessor() Processor {
+func NewTestProcessor() *DefaultProcessor {
 	return &DefaultProcessor{
 		signedMessageValidator: &TestSignedMessageValidator{},
 		blockRewarder:          &TestBlockRewarder{},

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -319,7 +319,7 @@ func applyMessageDirect(ctx context.Context, st state.Tree, vms vm.StorageMap, f
 	pdata := actor.MustConvertParams(params...)
 	msg := types.NewMessage(from, to, 0, value, method, pdata)
 	// this should never fail due to lack of gas since gas doesn't have meaning here
-	gasLimit := types.NewGasUnits(types.MaxGasUnits)
+	gasLimit := types.BlockGasLimit
 	smsg, err := types.NewSignedMessage(*msg, &signer{}, types.NewGasPrice(0), gasLimit)
 	if err != nil {
 		return nil, err
@@ -350,7 +350,7 @@ type messageValidator struct{}
 var _ consensus.SignedMessageValidator = (*messageValidator)(nil)
 
 // Validate always returns nil
-func (ggmv *messageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor, bh *types.BlockHeight) error {
+func (ggmv *messageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -808,7 +808,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 
 					// TODO: determine these algorithmically by simulating call and querying historical prices
 					gasPrice := types.NewGasPrice(0)
-					gasUnits := types.NewGasUnits(types.MaxGasUnits)
+					gasUnits := types.BlockGasLimit
 
 					val := result.SealingResult
 					// This call can fail due to, e.g. nonce collisions, so we retry to make sure we include it,

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -45,7 +45,7 @@ const queryDealProtocol = protocol.ID("/fil/storage/qry/1.0.0")
 
 // TODO: replace this with a queries to pick reasonable gas price and limits.
 const submitPostGasPrice = 0
-const submitPostGasLimit = 100000000000
+const submitPostGasLimit = 300
 
 const minerDatastorePrefix = "miner"
 const dealsAwatingSealDatastorePrefix = "dealsAwaitingSeal"

--- a/testhelpers/consensus.go
+++ b/testhelpers/consensus.go
@@ -113,7 +113,7 @@ type TestSignedMessageValidator struct{}
 var _ consensus.SignedMessageValidator = (*TestSignedMessageValidator)(nil)
 
 // Validate always returns nil
-func (tsmv *TestSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor, bh *types.BlockHeight) error {
+func (tsmv *TestSignedMessageValidator) Validate(ctx context.Context, msg *types.SignedMessage, fromActor *actor.Actor) error {
 	return nil
 }
 

--- a/types/metered_message.go
+++ b/types/metered_message.go
@@ -9,9 +9,8 @@ import (
 // GasUnits represents number of units of gas consumed
 type GasUnits = Uint64
 
-// MaxGasUnits is a convenience value for when we want to guarantee a direct message does not fail due
-//    to lack of gas
-const MaxGasUnits = ^uint64(0)
+// BlockGasLimit is the maximum amount of gas that can be used to execute messages in a single block
+var BlockGasLimit = NewGasUnits(10000000)
 
 func init() {
 	cbor.RegisterCborType(MeteredMessage{})

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -98,7 +98,7 @@ func (smsg *SignedMessage) String() string {
 }
 
 // NewSignedMessage accepts a message `msg` and a signer `s`. NewSignedMessage returns a `SignedMessage` containing
-// a signature derived from the seralized `msg` and `msg.From`
+// a signature derived from the serialized `msg` and `msg.From`
 func NewSignedMessage(msg Message, s Signer, gasPrice AttoFIL, gasLimit GasUnits) (*SignedMessage, error) {
 	meteredMsg := NewMeteredMessage(msg, gasPrice, gasLimit)
 

--- a/vm/context_test.go
+++ b/vm/context_test.go
@@ -45,7 +45,7 @@ func TestVMContextStorage(t *testing.T) {
 
 	to, err := cstate.GetActor(ctx, toAddr)
 	assert.NoError(err)
-	vmCtx := NewVMContext(nil, to, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+	vmCtx := NewVMContext(nil, to, msg, cstate, vms, NewGasTracker(), types.NewBlockHeight(0))
 
 	node, err := cbor.WrapObject([]byte("hello"), types.DefaultHashFunction, -1)
 	assert.NoError(err)
@@ -57,7 +57,7 @@ func TestVMContextStorage(t *testing.T) {
 	toActorBack, err := st.GetActor(ctx, toAddr)
 	assert.NoError(err)
 
-	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0)).ReadStorage()
+	storage, err := NewVMContext(nil, toActorBack, msg, cstate, vms, NewGasTracker(), types.NewBlockHeight(0)).ReadStorage()
 	assert.NoError(err)
 	assert.Equal(storage, node.RawData())
 }
@@ -88,7 +88,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -114,7 +114,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -145,7 +145,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, msg, tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(to, "foo", nil, []interface{}{})
@@ -176,7 +176,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -212,7 +212,7 @@ func TestVMContextSendFailures(t *testing.T) {
 			},
 		}
 
-		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		ctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		ctx.deps = deps
 
 		_, code, err := ctx.Send(newAddress(), "foo", nil, []interface{}{})
@@ -228,7 +228,7 @@ func TestVMContextSendFailures(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmctx := NewVMContext(actor1, actor2, newMsg(), tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		addr, err := vmctx.AddressForNewActor()
 
 		require.NoError(err)
@@ -259,10 +259,10 @@ func TestVMContextIsAccountActor(t *testing.T) {
 
 	accountActor, err := account.NewActor(types.NewAttoFILFromFIL(1000))
 	require.NoError(err)
-	ctx := NewVMContext(accountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), nil)
+	ctx := NewVMContext(accountActor, nil, nil, nil, vms, NewGasTracker(), nil)
 	assert.True(ctx.IsFromAccountActor())
 
 	nonAccountActor := actor.NewActor(types.NewCidForTestGetter()(), types.NewAttoFILFromFIL(1000))
-	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), nil)
+	ctx = NewVMContext(nonAccountActor, nil, nil, nil, vms, NewGasTracker(), nil)
 	assert.False(ctx.IsFromAccountActor())
 }

--- a/vm/errors/errors.go
+++ b/vm/errors/errors.go
@@ -154,7 +154,7 @@ func IsApplyErrorPermanent(err error) bool {
 	return ok && re.IsPermanent()
 }
 
-// ApplyErrorPermanent is an error indicaiting a permanent failure.
+// ApplyErrorPermanent is an error indicating a permanent failure.
 type ApplyErrorPermanent struct {
 	err error
 	msg string

--- a/vm/gas_tracker.go
+++ b/vm/gas_tracker.go
@@ -1,0 +1,52 @@
+package vm
+
+import (
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/filecoin-project/go-filecoin/vm/errors"
+)
+
+// GasTracker maintains the state of gas usage throughout the execution of a block and a message
+type GasTracker struct {
+	MsgGasLimit          types.GasUnits
+	gasConsumedByBlock   types.GasUnits
+	gasConsumedByMessage types.GasUnits
+}
+
+// NewGasTracker initializes a new empty gas tracker
+func NewGasTracker() *GasTracker {
+	return &GasTracker{
+		MsgGasLimit:          types.NewGasUnits(0),
+		gasConsumedByBlock:   types.NewGasUnits(0),
+		gasConsumedByMessage: types.NewGasUnits(0),
+	}
+}
+
+// ResetForNewMessage will reset the per-message gas accumulator and set the MsgGasLimit to that of the message.
+func (gasTracker *GasTracker) ResetForNewMessage(message types.MeteredMessage) {
+	gasTracker.MsgGasLimit = message.GasLimit
+	gasTracker.gasConsumedByMessage = types.NewGasUnits(0)
+}
+
+// Charge will add the gas charge to the current method gas context.
+func (gasTracker *GasTracker) Charge(cost types.GasUnits) error {
+	if gasTracker.gasConsumedByMessage+cost > gasTracker.MsgGasLimit {
+		gasTracker.gasConsumedByMessage = gasTracker.MsgGasLimit
+		gasTracker.gasConsumedByBlock += gasTracker.MsgGasLimit
+		return errors.NewRevertError("gas cost exceeds gas limit")
+	}
+
+	gasTracker.gasConsumedByMessage += cost
+	gasTracker.gasConsumedByBlock += cost
+	return nil
+}
+
+// GasAboveBlockLimit will return true if the MsgGasLimit of the current message is greater than the block gas limit.
+func (gasTracker *GasTracker) GasAboveBlockLimit() bool {
+	return gasTracker.MsgGasLimit > types.BlockGasLimit
+}
+
+// GasTooHighForCurrentBlock will return true if the MsgGasLimit of the current message
+// plus the gas used for the current block is greater than the block gas limit.
+func (gasTracker *GasTracker) GasTooHighForCurrentBlock() bool {
+	return gasTracker.MsgGasLimit+gasTracker.gasConsumedByBlock > types.BlockGasLimit
+}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -67,7 +67,7 @@ func TestSendErrorHandling(t *testing.T) {
 		}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -84,7 +84,7 @@ func TestSendErrorHandling(t *testing.T) {
 		deps := sendDeps{}
 
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)
@@ -106,7 +106,7 @@ func TestSendErrorHandling(t *testing.T) {
 		tree := state.NewCachedStateTree(&state.MockStateTree{NoMocks: true, BuiltinActors: map[cid.Cid]exec.ExecutableActor{
 			actor2.Code: &actor.FakeActor{},
 		}})
-		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, *types.ZeroAttoFIL, types.NewGasUnits(0), types.NewGasUnits(0), types.NewBlockHeight(0))
+		vmCtx := NewVMContext(actor1, actor2, msg, tree, vms, NewGasTracker(), types.NewBlockHeight(0))
 		_, code, sendErr := send(context.Background(), deps, vmCtx)
 
 		assert.Error(sendErr)


### PR DESCRIPTION
We add a per-block gas limit that prevents a block's messages from consuming more than a preset amount of gas. This is done via a `GasTracker` that performs the required accounting steps during the execution of the messages in a block.

Additionally, we
- Remove the unused `blockHeight` argument from the `Validate` function
- Create `isTemporaryError` and `isPermanentError` helpers in the processor
- Improve the capabilities of processor test helpers

Resolves #913 