### PR TITLE
include seal proof-bytes in commitSector message

### DIFF
--- a/actor/builtin/miner/miner.go
+++ b/actor/builtin/miner/miner.go
@@ -177,7 +177,7 @@ var minerExports = exec.Exports{
 		Return: []abi.Type{abi.SectorID},
 	},
 	"commitSector": &exec.FunctionSignature{
-		Params: []abi.Type{abi.SectorID, abi.Bytes, abi.Bytes, abi.Bytes},
+		Params: []abi.Type{abi.SectorID, abi.Bytes, abi.Bytes, abi.Bytes, abi.Bytes},
 		Return: []abi.Type{},
 	},
 	"getKey": &exec.FunctionSignature{
@@ -399,10 +399,9 @@ func (ma *Actor) GetSectorCommitments(ctx exec.VMContext) (map[string]types.Comm
 	return a, 0, nil
 }
 
-// CommitSector adds a commitment to the specified sector
-// The sector must not already be committed
-// 'size' is the total number of bytes stored in the sector
-func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR, commRStar []byte) (uint8, error) {
+// CommitSector adds a commitment to the specified sector. The sector must not
+// already be committed.
+func (ma *Actor) CommitSector(ctx exec.VMContext, sectorID uint64, commD, commR, commRStar, proof []byte) (uint8, error) {
 	if err := ctx.Charge(100); err != nil {
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}

--- a/actor/builtin/miner/miner_test.go
+++ b/actor/builtin/miner/miner_test.go
@@ -279,7 +279,7 @@ func TestMinerCommitSector(t *testing.T) {
 	commRStar := th.MakeCommitment()
 	commD := th.MakeCommitment()
 
-	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", uint64(1), commD, commR, commRStar)
+	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", uint64(1), commD, commR, commRStar, th.MakeRandomBytes(int(proofs.SealBytesLen)))
 	require.NoError(err)
 	require.NoError(res.ExecutionError)
 	require.Equal(uint8(0), res.Receipt.ExitCode)
@@ -292,7 +292,7 @@ func TestMinerCommitSector(t *testing.T) {
 	require.Equal(types.NewBlockHeight(3), types.NewBlockHeightFromBytes(res.Receipt.Return[0]))
 
 	// fail because commR already exists
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", uint64(1), commD, commR, commRStar)
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", uint64(1), commD, commR, commRStar, th.MakeRandomBytes(int(proofs.SealBytesLen)))
 	require.NoError(err)
 	require.EqualError(res.ExecutionError, "sector already committed")
 	require.Equal(uint8(0x23), res.Receipt.ExitCode)
@@ -307,13 +307,13 @@ func TestMinerSubmitPoSt(t *testing.T) {
 	minerAddr := createTestMiner(assert.New(t), st, vms, address.TestAddress, []byte("my public key"), origPid)
 
 	// add a sector
-	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", uint64(1), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment())
+	res, err := th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 3, "commitSector", uint64(1), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(int(proofs.SealBytesLen)))
 	require.NoError(err)
 	require.NoError(res.ExecutionError)
 	require.Equal(uint8(0), res.Receipt.ExitCode)
 
 	// add another sector
-	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", uint64(2), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment())
+	res, err = th.CreateAndApplyTestMessage(t, st, vms, minerAddr, 0, 4, "commitSector", uint64(2), th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(int(proofs.SealBytesLen)))
 	require.NoError(err)
 	require.NoError(res.ExecutionError)
 	require.Equal(uint8(0), res.Receipt.ExitCode)

--- a/chain/testing.go
+++ b/chain/testing.go
@@ -206,7 +206,7 @@ func CreateMinerWithPower(ctx context.Context,
 	// commit sector (thus adding power to miner and recording in storage market).
 	msgs := make([]*types.SignedMessage, power)
 	for i := 0; uint64(i) < power; i++ {
-		msg, err = th.CommitSectorMessage(minerAddr, sn.Addresses[0], nonce, sectorID, th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment())
+		msg, err = th.CommitSectorMessage(minerAddr, sn.Addresses[0], nonce, sectorID, th.MakeCommitment(), th.MakeCommitment(), th.MakeCommitment(), th.MakeRandomBytes(int(proofs.SealBytesLen)))
 		require.NoError(err)
 		msgs[i] = mockSign(sn, msg)
 		sectorID++

--- a/gengen/util/gengen.go
+++ b/gengen/util/gengen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/crypto"
+	"github.com/filecoin-project/go-filecoin/proofs"
 	"github.com/filecoin-project/go-filecoin/state"
 	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/vm"
@@ -268,6 +269,7 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			commD := make([]byte, 32)
 			commR := make([]byte, 32)
 			commRStar := make([]byte, 32)
+			sealProof := make([]byte, proofs.SealBytesLen)
 			if _, err := pnrg.Read(commD[:]); err != nil {
 				return nil, err
 			}
@@ -277,7 +279,10 @@ func setupMiners(st state.Tree, sm vm.StorageMap, keys []*types.KeyInfo, miners 
 			if _, err := pnrg.Read(commRStar[:]); err != nil {
 				return nil, err
 			}
-			_, err := applyMessageDirect(ctx, st, sm, addr, maddr, types.NewAttoFILFromFIL(0), "commitSector", sectorID, commD, commR, commRStar)
+			if _, err := pnrg.Read(sealProof[:]); err != nil {
+				return nil, err
+			}
+			_, err := applyMessageDirect(ctx, st, sm, addr, maddr, types.NewAttoFILFromFIL(0), "commitSector", sectorID, commD, commR, commRStar, sealProof)
 			if err != nil {
 				return nil, err
 			}

--- a/node/node.go
+++ b/node/node.go
@@ -818,7 +818,7 @@ func (node *Node) StartMining(ctx context.Context) error {
 					// This call can fail due to, e.g. nonce collisions, so we retry to make sure we include it,
 					// as our miners existence depends on this.
 					// TODO: what is the right number of retries?
-					err := porcelain.MessageSendWithRetry(node.miningCtx, node.PlumbingAPI, 10 /* retries */, node.GetBlockTime() /* wait per retry */, minerOwnerAddr, minerAddr, nil, "commitSector", gasPrice, gasUnits, val.SectorID, val.CommD[:], val.CommR[:], val.CommRStar[:])
+					err := porcelain.MessageSendWithRetry(node.miningCtx, node.PlumbingAPI, 10 /* retries */, node.GetBlockTime() /* wait per retry */, minerOwnerAddr, minerAddr, nil, "commitSector", gasPrice, gasUnits, val.SectorID, val.CommD[:], val.CommR[:], val.CommRStar[:], val.Proof[:])
 					if err != nil {
 						log.Errorf("failed to send commitSector message from %s to %s for sector with id %d: %s", minerOwnerAddr, minerAddr, val.SectorID, err)
 						continue

--- a/testhelpers/mining.go
+++ b/testhelpers/mining.go
@@ -2,13 +2,14 @@ package testhelpers
 
 import (
 	"crypto/rand"
-	"github.com/filecoin-project/go-filecoin/types"
-	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
 	"math/big"
 	"time"
 
+	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
+
 	"github.com/filecoin-project/go-filecoin/abi"
 	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
 )
 
 // BlockTimeTest is the block time used by workers during testing
@@ -25,8 +26,8 @@ func CreateMinerMessage(from address.Address, nonce uint64, pledge uint64, pid p
 }
 
 // CommitSectorMessage creates a message to commit a sector.
-func CommitSectorMessage(miner, from address.Address, nonce, sectorID uint64, commD, commR, commRStar []byte) (*types.Message, error) {
-	params, err := abi.ToEncodedValues(sectorID, commD, commR, commRStar)
+func CommitSectorMessage(miner, from address.Address, nonce, sectorID uint64, commD, commR, commRStar, proof []byte) (*types.Message, error) {
+	params, err := abi.ToEncodedValues(sectorID, commD, commR, commRStar, proof)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #1719 and enables #1659.

## What's in this PR?

- ensure seal proof-bytes are included in `commitSector` message [as per spec](https://github.com/filecoin-project/specs/blob/master/actors.md#commitsector)
- update various helpers and tests to use new message format