### PR TITLE
Feat/make dht work #1440

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -445,7 +445,7 @@ func (nc *Config) Build(ctx context.Context) (*Node, error) {
 		return nil, errors.Wrapf(err, "couldn't parse bootstrap addresses [%s]", ba)
 	}
 	minPeerThreshold := nd.Repo.Config().Bootstrap.MinPeerThreshold
-	nd.Bootstrapper = filnet.NewBootstrapper(bpi, nd.Host(), nd.Host().Network(), minPeerThreshold, period)
+	nd.Bootstrapper = filnet.NewBootstrapper(bpi, nd.Host(), nd.Host().Network(), nd.Router, minPeerThreshold, period)
 
 	// On-chain lookup service
 	defaultAddressGetter := func() (address.Address, error) {


### PR DESCRIPTION
This is a PR to close #1440.

Talking with @anacrolix and @vyzo it is clear that we are not adhering to DHT best practices by neglecting to call the `Bootstrap` method on a node's DHT instance.  This PR simply adds this process in.

Unfortunately there are some hiccups preventing this change from coming in with confidence that it addresses the original problem motivating these changes.  Specifically I am unable to reproduce the connection issues we used to see when a client attempted to make a deal with a miner without being directly connected to the miner in the swarm peers.  I can't reproduce because all peers connected to the bootstrappers end up connecting automatically.  This happens with both unNATed and NATed peers because of relay addresses. [More details here](https://github.com/filecoin-project/go-filecoin/issues/1440#issuecomment-457789428).  Talking with @vyzo this is likely due to DHT queries that the autorelay feature makes.

Without being able to reproduce non-connected peers I do not know if the autorelay's side effect of connecting peers is itself a full solution to the original issue.  Autorelay was certainly not designed to be a DHT bootstrapper.  My hypothesis is that it is not enough in general and we would see the original failure in more complicated network, for example in networks too big for all peers to connect to each other as a side effect of running autorelay, without adding in this DHT Bootstrap.

In an effort to not get blocked and ship more I recommend that we merge these changes without verifying that they solve a problem we can't reproduce.  If someone is able to reproduce the original problem or any other DHT issues in the future we can take them as they come.

--edit--
While writing realized that we could probably reproduce connection failure with a non-relay version of filecoin running in test cluster and two public nodes.  Will try that.

--edit edit--
Tried using code before relays running both on test cluster and on public nodes.  No good. Nodes again connected automatically.  Leaves me wondering how we ever ran into the original problem in the first place