### PR TITLE
hotfix: remove debug mode from bash script

### DIFF
--- a/bin/cluster_start
+++ b/bin/cluster_start
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -x
 
 echo "in cluster_start"
 grep -qs "minerAddress" /var/local/filecoin/config.json /dev/null 2>&1

--- a/bin/node_restart
+++ b/bin/node_restart
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -e
 filecoin_repo="/var/local/filecoin"
 filecoin_exec="go-filecoin --repodir=${filecoin_repo}"
 


### PR DESCRIPTION
Removes `-x` flag (debug output) from bash scripts in order to minimize confusion in the logs.