### PR TITLE
Create payments for miners

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-filecoin/mining"
 	"github.com/filecoin-project/go-filecoin/plumbing"
 	pbConfig "github.com/filecoin-project/go-filecoin/plumbing/cfg"
+	"github.com/filecoin-project/go-filecoin/plumbing/chn"
 	"github.com/filecoin-project/go-filecoin/plumbing/msg"
 	"github.com/filecoin-project/go-filecoin/plumbing/mthdsig"
 	"github.com/filecoin-project/go-filecoin/porcelain"
@@ -154,12 +155,14 @@ func TestNodeStartMining(t *testing.T) {
 
 	// TODO we need a principled way to construct an API that can be used both by node and by
 	// tests. It should enable selective replacement of dependencies.
-	sigGetter := mthdsig.NewGetter(minerNode.ChainReader)
-	msgQueryer := msg.NewQueryer(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore)
-	msgSender := msg.NewSender(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, minerNode.PubSub.Publish)
-	msgWaiter := msg.NewWaiter(minerNode.ChainReader, minerNode.Blockstore, minerNode.CborStore())
-	config := pbConfig.NewConfig(minerNode.Repo)
-	plumbingAPI := plumbing.New(sigGetter, msgQueryer, msgSender, msgWaiter, config)
+	plumbingAPI := plumbing.New(&plumbing.APIDeps{
+		SigGetter:  mthdsig.NewGetter(minerNode.ChainReader),
+		MsgQueryer: msg.NewQueryer(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.CborStore(), minerNode.Blockstore),
+		MsgSender:  msg.NewSender(minerNode.Repo, minerNode.Wallet, minerNode.ChainReader, minerNode.MsgPool, minerNode.PubSub.Publish),
+		MsgWaiter:  msg.NewWaiter(minerNode.ChainReader, minerNode.Blockstore, minerNode.CborStore()),
+		Config:     pbConfig.NewConfig(minerNode.Repo),
+		Chain:      chn.New(minerNode.ChainReader),
+	})
 	porcelainAPI := porcelain.New(plumbingAPI)
 
 	seed.GiveKey(t, minerNode, 0)

--- a/plumbing/chn/chain.go
+++ b/plumbing/chn/chain.go
@@ -1,0 +1,26 @@
+package chn
+
+import (
+	"context"
+)
+
+// ChainReader defines a source of block history.
+type ChainReader interface {
+	BlockHistory(ctx context.Context) <-chan interface{}
+}
+
+// Lser is plumbing implementation for inspecting the blockchain
+type Lser struct {
+	chainReader ChainReader
+}
+
+// New returns a new Lser.
+func New(chainReader ChainReader) *Lser {
+	return &Lser{chainReader: chainReader}
+}
+
+// Ls returns a channel historical tip sets from head to genesis
+// If an error is encountered while reading the chain, the error is sent, and the channel is closed.
+func (c *Lser) Ls(ctx context.Context) <-chan interface{} {
+	return c.chainReader.BlockHistory(ctx)
+}

--- a/plumbing/chn/chain_test.go
+++ b/plumbing/chn/chain_test.go
@@ -1,0 +1,57 @@
+package chn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type MockChainReader struct {
+	tipSets []consensus.TipSet
+}
+
+// BlockHistory returns the head of the chain tracked by the store.
+func (mcr *MockChainReader) BlockHistory(ctx context.Context) <-chan interface{} {
+	out := make(chan interface{}, len(mcr.tipSets))
+
+	go func() {
+		defer close(out)
+
+		for _, tipSet := range mcr.tipSets {
+			out <- tipSet
+		}
+	}()
+
+	return out
+}
+
+func TestChainLs(t *testing.T) {
+	t.Parallel()
+	t.Run("Ls creates a channel of tipsets", func(t *testing.T) {
+		t.Parallel()
+		assert := assert.New(t)
+		require := require.New(t)
+
+		expected1, err := consensus.NewTipSet(types.NewBlockForTest(nil, 2))
+		require.NoError(err)
+
+		expected2, err := consensus.NewTipSet(types.NewBlockForTest(nil, 3))
+		require.NoError(err)
+
+		chainAPI := New(&MockChainReader{
+			tipSets: []consensus.TipSet{expected1, expected2},
+		})
+
+		ls := chainAPI.Ls(context.Background())
+
+		actual1 := <-ls
+		assert.Equal(expected1, actual1)
+
+		actual2 := <-ls
+		assert.Equal(expected2, actual2)
+	})
+}

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -5,6 +5,9 @@ import (
 	"math/big"
 	"time"
 
+	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
+
+	minerActor "github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/plumbing"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -38,10 +41,35 @@ func New(plumbing *plumbing.API) *API {
 	return &API{plumbing}
 }
 
+// ChainBlockHeight determines the current block height
+func (a *API) ChainBlockHeight(ctx context.Context) (*types.BlockHeight, error) {
+	return ChainBlockHeight(ctx, a)
+}
+
+// CreatePayments establishes a payment channel and create multiple payments against it
+func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (*CreatePaymentsReturn, error) {
+	return CreatePayments(ctx, a, config)
+}
+
 // MessageSendWithRetry sends a message and retries if it does not appear on chain. See implementation
 // for more details.
 func (a *API) MessageSendWithRetry(ctx context.Context, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) (err error) {
 	return MessageSendWithRetry(ctx, a, numRetries, waitDuration, from, to, val, method, gasPrice, gasLimit, params...)
+}
+
+// MinerGetAsk queries for an ask of the given miner
+func (a *API) MinerGetAsk(ctx context.Context, minerAddr address.Address, askID uint64) (minerActor.Ask, error) {
+	return MinerGetAsk(ctx, a, minerAddr, askID)
+}
+
+// MinerGetOwnerAddress queries for the owner address of the given miner
+func (a *API) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
+	return MinerGetOwnerAddress(ctx, a, minerAddr)
+}
+
+// MinerGetPeerID queries for the peer id of the given miner
+func (a *API) MinerGetPeerID(ctx context.Context, minerAddr address.Address) (peer.ID, error) {
+	return MinerGetPeerID(ctx, a, minerAddr)
 }
 
 // MinerSetPrice configures the price of storage. See implementation for details.

--- a/porcelain/chain.go
+++ b/porcelain/chain.go
@@ -1,0 +1,30 @@
+package porcelain
+
+import (
+	"context"
+	"errors"
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+type chPlumbing interface {
+	ChainLs(ctx context.Context) <-chan interface{}
+}
+
+// ChainBlockHeight determines the current block height
+func ChainBlockHeight(ctx context.Context, plumbing chPlumbing) (*types.BlockHeight, error) {
+	lsCtx, cancelLs := context.WithCancel(ctx)
+	tipSetCh := plumbing.ChainLs(lsCtx)
+	head := <-tipSetCh
+	cancelLs()
+
+	if head == nil {
+		return nil, errors.New("could not retrieve block height")
+	}
+
+	currentHeight, err := head.(consensus.TipSet).Height()
+	if err != nil {
+		return nil, err
+	}
+	return types.NewBlockHeight(currentHeight), nil
+}

--- a/porcelain/payments.go
+++ b/porcelain/payments.go
@@ -1,0 +1,181 @@
+package porcelain
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
+	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
+
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+// cpPlumbing is the subset of the plumbing.API that CreatePayments uses.
+type cpPlumbing interface {
+	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error)
+	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
+	ChainLs(ctx context.Context) <-chan interface{}
+}
+
+// CreatePaymentsParams structures all the parameters for the CreatePayments command. All values are required.
+type CreatePaymentsParams struct {
+	// From is the address of the payer.
+	From address.Address
+
+	// To is the address of the target of the payments.
+	To address.Address
+
+	// Value is the amount of the payment channel that will be opened and the sum of all the payments.
+	Value types.AttoFIL
+
+	// Duration is the amount of time (in block height) the payments will cover.
+	Duration uint64
+
+	// PaymentInterval is the time between payments (in block height)
+	PaymentInterval uint64
+
+	// ChannelExpiry is the time (block height) at which the payment channel will close. It must
+	// be greater than the current block height plus Duration.
+	ChannelExpiry types.BlockHeight
+
+	// GasPrice is the price of gas to be paid to create the payment channel
+	GasPrice types.AttoFIL
+
+	// GasLimit is the maximum amount of gas to be paid creating the payment channel.
+	GasLimit types.GasUnits
+}
+
+// CreatePaymentsReturn collects relevant stats from the create payments process
+type CreatePaymentsReturn struct {
+	// CreatePaymentsParams are the parameters given to create the payment
+	CreatePaymentsParams
+
+	// Channel is the id of the payment channel
+	Channel *types.ChannelID
+
+	// ChannelMsgCid is the id of the message sent to create the payment channel
+	ChannelMsgCid cid.Cid
+
+	// GasAttoFIL is the amount spent on gas creating the channel
+	GasAttoFIL *types.AttoFIL
+
+	// Vouchers are the payment vouchers created to pay the target at regular intervals.
+	Vouchers []*paymentbroker.PaymentVoucher
+}
+
+// CreatePayments establishes a payment channel and create multiple payments against it
+func CreatePayments(ctx context.Context, plumbing cpPlumbing, config CreatePaymentsParams) (*CreatePaymentsReturn, error) {
+	// validate
+	if config.From.Empty() {
+		return nil, errors.New("From cannot be empty")
+	}
+	if config.To.Empty() {
+		return nil, errors.New("To cannot be empty")
+	}
+	if config.PaymentInterval < 1 {
+		return nil, errors.New("PaymentInterval must be at least 1")
+	}
+
+	// get current block height
+	currentHeight, err := ChainBlockHeight(ctx, plumbing)
+	if err != nil {
+		return nil, errors.Wrap(err, "Could not retrieve block height for making payments")
+	}
+
+	// validate that channel expiry gives us enough time
+	lastPayment := currentHeight.Add(types.NewBlockHeight(config.Duration))
+	if config.ChannelExpiry.LessThan(lastPayment) {
+		return nil, fmt.Errorf("channel would expire (%s) before last payment is made (%d)", config.ChannelExpiry.String(), lastPayment)
+	}
+
+	response := &CreatePaymentsReturn{
+		CreatePaymentsParams: config,
+	}
+
+	// Create channel
+	response.ChannelMsgCid, err = plumbing.MessageSend(ctx,
+		config.From,
+		address.PaymentBrokerAddress,
+		&config.Value,
+		config.GasPrice,
+		config.GasLimit,
+		"createChannel",
+		config.To,
+		&config.ChannelExpiry)
+	if err != nil {
+		return response, err
+	}
+
+	// wait for response
+	err = plumbing.MessageWait(ctx, response.ChannelMsgCid, func(block *types.Block, message *types.SignedMessage, receipt *types.MessageReceipt) error {
+		if receipt.ExitCode != 0 {
+			return fmt.Errorf("createChannel failed %d", receipt.ExitCode)
+		}
+
+		response.Channel = types.NewChannelIDFromBytes(receipt.Return[0])
+		response.GasAttoFIL = receipt.GasAttoFIL
+		return nil
+	})
+	if err != nil {
+		return response, err
+	}
+
+	// compute value per payment. Roughly value/num payments. Exactly ceil(value*interval/duration).
+	intervalAsBigInt := big.NewInt(int64(config.PaymentInterval))
+	// Convert to AttoFIL, because values have to be the same type.
+	durationAsAttoFIL := types.NewAttoFIL(big.NewInt(int64(config.Duration)))
+	valuePerPayment := *config.Value.MulBigInt(intervalAsBigInt).DivCeil(durationAsAttoFIL)
+
+	// generate payments
+	response.Vouchers = []*paymentbroker.PaymentVoucher{}
+	voucherAmount := types.ZeroAttoFIL
+	for i := 0; uint64(i+1)*config.PaymentInterval < config.Duration; i++ {
+		voucherAmount = voucherAmount.Add(&valuePerPayment)
+		if voucherAmount.GreaterThan(&config.Value) {
+			voucherAmount = &config.Value
+		}
+
+		validAt := currentHeight.Add(types.NewBlockHeight(uint64(i+1) * config.PaymentInterval))
+		err = createPayment(ctx, plumbing, response, voucherAmount, validAt)
+		if err != nil {
+			return response, err
+		}
+	}
+
+	if voucherAmount.LessThan(&config.Value) {
+		validAt := currentHeight.Add(types.NewBlockHeight(config.Duration))
+		err = createPayment(ctx, plumbing, response, &config.Value, validAt)
+		if err != nil {
+			return response, err
+		}
+	}
+
+	return response, nil
+}
+
+func createPayment(ctx context.Context, plumbing cpPlumbing, response *CreatePaymentsReturn, amount *types.AttoFIL, validAt *types.BlockHeight) error {
+	ret, _, err := plumbing.MessageQuery(ctx,
+		response.From,
+		address.PaymentBrokerAddress,
+		"voucher",
+		response.Channel,
+		amount,
+		validAt)
+	if err != nil {
+		return err
+	}
+
+	var voucher paymentbroker.PaymentVoucher
+	if err := cbor.DecodeInto(ret[0], &voucher); err != nil {
+		return err
+	}
+
+	response.Vouchers = append(response.Vouchers, &voucher)
+	return nil
+}

--- a/porcelain/payments_test.go
+++ b/porcelain/payments_test.go
@@ -1,0 +1,294 @@
+package porcelain
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/consensus"
+	"github.com/filecoin-project/go-filecoin/exec"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	startingBlock   = 77
+	channelID       = 4
+	paymentInterval = uint64(5)
+)
+
+type paymentsTestPlumbing struct {
+	tipSets []*consensus.TipSet
+	msgCid  cid.Cid
+
+	messageSend  func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
+	messageWait  func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
+	messageQuery func(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error)
+}
+
+func newTestCreatePaymentsPlumbing() *paymentsTestPlumbing {
+	var payer address.Address
+	var target address.Address
+	channelID := types.NewChannelID(channelID)
+	cidGetter := types.NewCidForTestGetter()
+	msgCid := cidGetter()
+	tipSet, err := consensus.NewTipSet(&types.Block{
+		Nonce:  43,
+		Height: startingBlock,
+	})
+	if err != nil {
+		panic("could not create tipset")
+	}
+	return &paymentsTestPlumbing{
+		msgCid:  msgCid,
+		tipSets: []*consensus.TipSet{&tipSet},
+		messageSend: func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+			payer = from
+			target = params[0].(address.Address)
+			return msgCid, nil
+		},
+		messageWait: func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+			return cb(nil, nil, &types.MessageReceipt{
+				ExitCode:   uint8(0),
+				Return:     []types.Bytes{channelID.Bytes()},
+				GasAttoFIL: types.NewAttoFILFromFIL(9),
+			})
+		},
+		messageQuery: func(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
+			voucher := &paymentbroker.PaymentVoucher{
+				Channel: *channelID,
+				Payer:   payer,
+				Target:  target,
+				Amount:  *params[1].(*types.AttoFIL),
+				ValidAt: *params[2].(*types.BlockHeight),
+			}
+			voucherBytes, err := actor.MarshalStorage(voucher)
+			if err != nil {
+				panic(err)
+			}
+			return [][]byte{voucherBytes}, nil, nil
+		},
+	}
+}
+
+func (ptp *paymentsTestPlumbing) MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+	return ptp.messageSend(ctx, from, to, value, gasPrice, gasLimit, method, params...)
+}
+
+func (ptp *paymentsTestPlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+	return ptp.messageWait(ctx, msgCid, cb)
+}
+
+func (ptp *paymentsTestPlumbing) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
+	return ptp.messageQuery(ctx, optFrom, to, method, params...)
+}
+
+func (ptp *paymentsTestPlumbing) ChainLs(ctx context.Context) <-chan interface{} {
+	out := make(chan interface{}, len(ptp.tipSets))
+
+	go func() {
+		defer close(out)
+
+		for _, tipSet := range ptp.tipSets {
+			out <- *tipSet
+		}
+	}()
+
+	return out
+}
+
+func validPaymentsConfig() CreatePaymentsParams {
+	addresses := address.NewForTestGetter()
+	from := addresses()
+	to := addresses()
+
+	return CreatePaymentsParams{
+		From:            from,
+		To:              to,
+		Value:           *types.NewAttoFILFromFIL(93),
+		Duration:        50,
+		PaymentInterval: paymentInterval,
+		ChannelExpiry:   *types.NewBlockHeight(500),
+		GasPrice:        *types.NewAttoFILFromFIL(3),
+		GasLimit:        types.NewGasUnits(300),
+	}
+}
+
+func TestCreatePayments(t *testing.T) {
+	successPlumbing := newTestCreatePaymentsPlumbing()
+
+	t.Run("Creates channel and creates payments", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		config := validPaymentsConfig()
+		paymentResponse, err := CreatePayments(context.Background(), successPlumbing, config)
+		require.NoError(err)
+
+		// assert we get stats in the responses
+		assert.Equal(config.From, paymentResponse.From)
+		assert.Equal(config.To, paymentResponse.To)
+		assert.Equal(successPlumbing.msgCid, paymentResponse.ChannelMsgCid)
+		assert.Equal(types.NewChannelID(4), paymentResponse.Channel)
+		assert.Equal(types.NewAttoFILFromFIL(9), paymentResponse.GasAttoFIL)
+
+		// Assert the vouchers have been properly constructed.
+		// ValidAts should start at the current block + the interval, and go up by the interval each time.
+		// Amounts should evenly divide the total value.
+		require.Len(paymentResponse.Vouchers, 10)
+
+		expectedValuePerPayment, ok := types.NewAttoFILFromFILString("9.3")
+		require.True(ok)
+
+		for i := 0; i < 9; i++ {
+			assert.Equal(*types.NewChannelID(channelID), paymentResponse.Vouchers[i].Channel)
+			assert.Equal(config.From, paymentResponse.Vouchers[i].Payer)
+			assert.Equal(config.To, paymentResponse.Vouchers[i].Target)
+			assert.Equal(*types.NewBlockHeight(startingBlock + config.PaymentInterval*uint64(i+1)), paymentResponse.Vouchers[i].ValidAt)
+			assert.Equal(*expectedValuePerPayment.MulBigInt(big.NewInt(int64(i + 1))), paymentResponse.Vouchers[i].Amount)
+		}
+
+		// last payment should be for the full amount
+		assert.Equal(*types.NewChannelID(channelID), paymentResponse.Vouchers[9].Channel)
+		assert.Equal(config.From, paymentResponse.Vouchers[9].Payer)
+		assert.Equal(config.To, paymentResponse.Vouchers[9].Target)
+		assert.Equal(*types.NewBlockHeight(startingBlock + config.PaymentInterval*uint64(10)), paymentResponse.Vouchers[9].ValidAt)
+		assert.Equal(config.Value, paymentResponse.Vouchers[9].Amount)
+	})
+
+	t.Run("Validates from", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		config := validPaymentsConfig()
+		config.From = address.Address{}
+		_, err := CreatePayments(context.Background(), successPlumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "From")
+	})
+
+	t.Run("Validates to", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		config := validPaymentsConfig()
+		config.To = address.Address{}
+		_, err := CreatePayments(context.Background(), successPlumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "To")
+	})
+
+	t.Run("Validates payment interval", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		config := validPaymentsConfig()
+		config.PaymentInterval = 0
+		_, err := CreatePayments(context.Background(), successPlumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "PaymentInterval")
+	})
+
+	t.Run("Validates channel expiry", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		config := validPaymentsConfig()
+		config.ChannelExpiry = *types.NewBlockHeight(startingBlock + config.PaymentInterval*10 - 1)
+		_, err := CreatePayments(context.Background(), successPlumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "channel would expire")
+	})
+
+	t.Run("Errors retrieving block height are surfaced", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newTestCreatePaymentsPlumbing()
+		plumbing.tipSets = []*consensus.TipSet{}
+
+		config := validPaymentsConfig()
+		_, err := CreatePayments(context.Background(), plumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "block height")
+
+		plumbing = newTestCreatePaymentsPlumbing()
+		ts := consensus.TipSet{}
+		plumbing.tipSets = []*consensus.TipSet{&ts}
+
+		config = validPaymentsConfig()
+		_, err = CreatePayments(context.Background(), plumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "block height")
+	})
+
+	t.Run("Errors creating channel are surfaced", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newTestCreatePaymentsPlumbing()
+		plumbing.messageSend = func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+			return cid.Cid{}, errors.New("Error in MessageSend")
+		}
+
+		config := validPaymentsConfig()
+		_, err := CreatePayments(context.Background(), plumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "MessageSend")
+	})
+
+	t.Run("Errors waiting for message are surfaced", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newTestCreatePaymentsPlumbing()
+		plumbing.messageWait = func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+			return errors.New("Error in MessageWait")
+		}
+
+		config := validPaymentsConfig()
+		_, err := CreatePayments(context.Background(), plumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "MessageWait")
+	})
+
+	t.Run("Errors in create channel response are surfaced", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newTestCreatePaymentsPlumbing()
+		plumbing.messageWait = func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+			receipt := &types.MessageReceipt{
+				ExitCode: 1,
+			}
+			return cb(nil, nil, receipt)
+		}
+
+		config := validPaymentsConfig()
+		_, err := CreatePayments(context.Background(), plumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "createChannel failed")
+	})
+
+	t.Run("Errors in creating vouchers are surfaced", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		plumbing := newTestCreatePaymentsPlumbing()
+		plumbing.messageQuery = func(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
+			return nil, nil, errors.New("Errors in MessageQuery")
+		}
+
+		config := validPaymentsConfig()
+		_, err := CreatePayments(context.Background(), plumbing, config)
+		require.Error(err)
+		assert.Contains(err.Error(), "MessageQuery")
+	})
+}

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -1,0 +1,218 @@
+package storage
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
+	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
+	"gx/ipfs/QmZNkThpqfVXs9GNbexPrfBbXSLNYeKrE7jwFM2oqHbyqN/go-libp2p-protocol"
+	"gx/ipfs/Qmf4xQhNomPNhrtZc67qSnfJSjxjXs9LWvknJtSXwimPrM/go-datastore/query"
+
+	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/porcelain"
+	"github.com/filecoin-project/go-filecoin/repo"
+	"github.com/filecoin-project/go-filecoin/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProposeDeal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	addressCreator := address.NewForTestGetter()
+	cidCreator := types.NewCidForTestGetter()
+
+	var proposal *DealProposal
+
+	testNode := newTestClientNode(func(request interface{}) (interface{}, error) {
+		p, ok := request.(*DealProposal)
+		require.True(ok)
+		proposal = p
+
+		return &DealResponse{
+			State:       Accepted,
+			Message:     "OK",
+			ProposalCid: p.PieceRef,
+		}, nil
+	})
+
+	testAPI := newTestClientAPI()
+	testRepo := repo.NewInMemoryRepo()
+
+	client, err := NewClient(testNode, testAPI, testRepo.DealsDs)
+	require.NoError(err)
+
+	dataCid := cidCreator()
+	minerAddr := addressCreator()
+	ctx := context.Background()
+	askID := uint64(67)
+	duration := uint64(10000)
+	dealResponse, err := client.ProposeDeal(ctx, minerAddr, dataCid, askID, duration, false)
+	require.NoError(err)
+
+	t.Run("and creates proposal from parameters", func(t *testing.T) {
+		assert.Equal(dataCid, proposal.PieceRef)
+		assert.Equal(duration, proposal.Duration)
+		assert.Equal(minerAddr, proposal.MinerAddress)
+	})
+
+	t.Run("and creates proposal with file size", func(t *testing.T) {
+		expectedFileSize, err := testNode.GetFileSize(ctx, dataCid)
+		require.NoError(err)
+		assert.Equal(types.NewBytesAmount(expectedFileSize), proposal.Size)
+	})
+
+	t.Run("and computes the correct total price", func(t *testing.T) {
+		expectedAskPrice := types.NewAttoFILFromFIL(32) // from test plumbing
+		expectedFileSize, err := testNode.GetFileSize(ctx, dataCid)
+		require.NoError(err)
+
+		expectedTotalPrice := expectedAskPrice.MulBigInt(big.NewInt(int64(expectedFileSize * duration)))
+		assert.Equal(expectedTotalPrice, proposal.TotalPrice)
+	})
+
+	t.Run("and creates a new payment channel", func(t *testing.T) {
+		// correct payment id and message cid in proposal implies a call to createChannel
+		assert.Equal(testAPI.channelID, proposal.Payment.Channel)
+		assert.Equal(testAPI.msgCid.String(), proposal.Payment.ChannelMsgCid)
+	})
+
+	t.Run("and creates payment info", func(t *testing.T) {
+		assert.Equal(int(duration/VoucherInterval), len(proposal.Payment.Vouchers))
+
+		lastValidAt := types.NewBlockHeight(0)
+		for i, voucher := range proposal.Payment.Vouchers {
+			assert.Equal(testAPI.channelID, &voucher.Channel)
+			assert.True(voucher.ValidAt.GreaterThan(lastValidAt))
+			assert.Equal(testAPI.target, voucher.Target)
+			assert.Equal(testAPI.perPayment.MulBigInt(big.NewInt(int64(i+1))), &voucher.Amount)
+			assert.Equal(testAPI.payer, voucher.Payer)
+			lastValidAt = &voucher.ValidAt
+		}
+	})
+
+	t.Run("and sends proposal and stores response", func(t *testing.T) {
+		assert.NotNil(dealResponse)
+
+		assert.Equal(Accepted, dealResponse.State)
+
+		res, err := testRepo.DealsDs.Query(query.Query{
+			Prefix: "/" + clientDatastorePrefix,
+		})
+		require.NoError(err)
+
+		// expect one entry to be the response
+		var response *DealResponse
+		for entry := range res.Next() {
+			var deal clientDeal
+			require.NoError(cbor.DecodeInto(entry.Value, &deal))
+			response = deal.Response
+		}
+
+		assert.NotNil(response)
+		assert.Equal(response, dealResponse)
+	})
+}
+
+type clientTestAPI struct {
+	blockHeight *types.BlockHeight
+	channelID   *types.ChannelID
+	msgCid      cid.Cid
+	payer       address.Address
+	target      address.Address
+	perPayment  *types.AttoFIL
+}
+
+func newTestClientAPI() *clientTestAPI {
+	cidGetter := types.NewCidForTestGetter()
+	addressGetter := address.NewForTestGetter()
+
+	return &clientTestAPI{
+		blockHeight: types.NewBlockHeight(773),
+		msgCid:      cidGetter(),
+		channelID:   types.NewChannelID(23),
+		payer:       addressGetter(),
+		target:      addressGetter(),
+		perPayment:  types.NewAttoFILFromFIL(10),
+	}
+}
+
+func (ctp *clientTestAPI) ChainBlockHeight(ctx context.Context) (*types.BlockHeight, error) {
+	return ctp.blockHeight, nil
+}
+
+func (ctp *clientTestAPI) CreatePayments(ctx context.Context, config porcelain.CreatePaymentsParams) (*porcelain.CreatePaymentsReturn, error) {
+	resp := &porcelain.CreatePaymentsReturn{
+		CreatePaymentsParams: config,
+		Channel:              ctp.channelID,
+		ChannelMsgCid:        ctp.msgCid,
+		GasAttoFIL:           types.NewAttoFILFromFIL(100),
+		Vouchers:             make([]*paymentbroker.PaymentVoucher, 10),
+	}
+
+	for i := 0; i < 10; i++ {
+		resp.Vouchers[i] = &paymentbroker.PaymentVoucher{
+			Channel: *ctp.channelID,
+			Payer:   ctp.payer,
+			Target:  ctp.target,
+			Amount:  *ctp.perPayment.MulBigInt(big.NewInt(int64(i + 1))),
+			ValidAt: *ctp.blockHeight.Add(types.NewBlockHeight(uint64(i+1) * VoucherInterval)),
+		}
+	}
+	return resp, nil
+}
+
+func (ctp *clientTestAPI) MinerGetAsk(ctx context.Context, minerAddr address.Address, askID uint64) (miner.Ask, error) {
+	return miner.Ask{
+		Price:  types.NewAttoFILFromFIL(32),
+		Expiry: types.NewBlockHeight(41),
+		ID:     big.NewInt(4),
+	}, nil
+}
+
+func (ctp *clientTestAPI) MinerGetOwnerAddress(ctx context.Context, minerAddr address.Address) (address.Address, error) {
+	return address.TestAddress, nil
+}
+
+func (ctp *clientTestAPI) MinerGetPeerID(ctx context.Context, minerAddr address.Address) (peer.ID, error) {
+	id, err := peer.IDB58Decode("QmWbMozPyW6Ecagtxq7SXBXXLY5BNdP1GwHB2WoZCKMvcb")
+	if err != nil {
+		panic("Could not create peer id")
+	}
+	return id, nil
+}
+
+func (ctp *clientTestAPI) ConfigGet(dottedPath string) (interface{}, error) {
+	// always just default address
+	return ctp.payer, nil
+}
+
+type testClientNode struct {
+	responder func(request interface{}) (interface{}, error)
+}
+
+func newTestClientNode(responder func(request interface{}) (interface{}, error)) *testClientNode {
+	return &testClientNode{
+		responder: responder,
+	}
+}
+
+func (tcn *testClientNode) GetFileSize(context.Context, cid.Cid) (uint64, error) {
+	return 1000000000, nil
+}
+
+func (tcn *testClientNode) MakeProtocolRequest(ctx context.Context, protocol protocol.ID, peer peer.ID, request interface{}, response interface{}) error {
+	dealResponse := response.(*DealResponse)
+	res, err := tcn.responder(request)
+	if err != nil {
+		return err
+	}
+	*dealResponse = *res.(*DealResponse)
+	return nil
+}

--- a/types/atto_fil.go
+++ b/types/atto_fil.go
@@ -154,6 +154,20 @@ func (z *AttoFIL) MulBigInt(x *big.Int) *AttoFIL {
 	return &AttoFIL{val: newVal}
 }
 
+// DivCeil returns the minimum number of times this value can be divided into smaller amounts
+// such that none of the smaller amounts are greater than the given divisor.
+// Equal to ceil(z/y) if AttoFIL could be fractional.
+// If y is zero a panic will occur.
+func (z *AttoFIL) DivCeil(y *AttoFIL) *AttoFIL {
+	value, remainder := big.NewInt(0).DivMod(z.val, y.val, big.NewInt(0))
+
+	if remainder.Cmp(big.NewInt(0)) == 0 {
+		return NewAttoFIL(value)
+	}
+
+	return NewAttoFIL(big.NewInt(0).Add(value, big.NewInt(1)))
+}
+
 // Equal returns true if z = y
 func (z *AttoFIL) Equal(y *AttoFIL) bool {
 	ensureZeroAmounts(&z, &y)

--- a/types/atto_fil_test.go
+++ b/types/atto_fil_test.go
@@ -174,6 +174,22 @@ func TestMulInt(t *testing.T) {
 	})
 }
 
+func TestDivCeil(t *testing.T) {
+	x := AttoFIL{val: big.NewInt(200)}
+
+	t.Run("returns exactly the dividend when y divides x", func(t *testing.T) {
+		assert := assert.New(t)
+		actual := x.DivCeil(&AttoFIL{val: big.NewInt(10)})
+		assert.Equal(NewAttoFIL(big.NewInt(20)), actual)
+	})
+
+	t.Run("rounds up when y does not divide x", func(t *testing.T) {
+		assert := assert.New(t)
+		actual := x.DivCeil(&AttoFIL{val: big.NewInt(9)})
+		assert.Equal(NewAttoFIL(big.NewInt(23)), actual)
+	})
+}
+
 func TestPriceCalculation(t *testing.T) {
 	price := NewAttoFILFromFIL(123)
 	numBytes := NewBytesAmount(10)


### PR DESCRIPTION
### Problem

Technically it is currently possible to pay miners for storing files.This is a completely ad hoc and manual process, however. We need to automate the process of making storage deals with payment. Specifically, we need to automatically add a payment channel for a deal, generate all the payment vouchers for the deal in advance and send them to the miner as part of the deal.

### Solution

This PR introduces this functionality to the storage client. It also introduces a new CreatePayments porcelain function to accomplish this. As part of this development, a lot of functionality needed to be moved to porcelain or plumbing, which explains the length of this PR.