### PR TITLE
Replace API IDDetails.ID with a peer.ID object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ go run ./build/*.go deps
 # First, build the binary...
 go run ./build/*.go build
 
-# Install go-filecoin to ${GOPATH}/bin
+# Install go-filecoin to ${GOPATH}/bin (necessary for tests)
 go run ./build/*.go install
 
 # Then, run the tests.

--- a/api/id.go
+++ b/api/id.go
@@ -1,10 +1,15 @@
 package api
 
+import (
+	"encoding/json"
+	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
+)
+
 // IDDetails is a collection of information about a node.
 // TODO: do we want to use strings here, or concrete types?
 type IDDetails struct {
 	Addresses       []string
-	ID              string
+	ID              peer.ID
 	AgentVersion    string
 	ProtocolVersion string
 	PublicKey       string
@@ -15,4 +20,48 @@ type IDDetails struct {
 type ID interface {
 	// Details, returns detailed information about the underlying node.
 	Details() (*IDDetails, error)
+}
+
+// MarshalJSON implements json.Marshaler
+func (idd IDDetails) MarshalJSON() ([]byte, error) {
+	v := map[string]interface{}{
+		"Addresses":       idd.Addresses,
+		"ID":              idd.ID.Pretty(),
+		"AgentVersion":    idd.AgentVersion,
+		"ProtocolVersion": idd.ProtocolVersion,
+		"PublicKey":       idd.PublicKey,
+	}
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON implements Unmarshaler
+func (idd *IDDetails) UnmarshalJSON(data []byte) error {
+	var v map[string]*json.RawMessage
+	var err error
+	if err = json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(*v["Addresses"], &idd.Addresses); err != nil {
+		return err
+	}
+
+	var id string
+	if err = json.Unmarshal(*v["ID"], &id); err != nil {
+		return err
+	}
+	if idd.ID, err = peer.IDB58Decode(id); err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(*v["AgentVersion"], &idd.AgentVersion); err != nil {
+		return err
+	}
+	if err = json.Unmarshal(*v["ProtocolVersion"], &idd.ProtocolVersion); err != nil {
+		return err
+	}
+	if err = json.Unmarshal(*v["PublicKey"], &idd.PublicKey); err != nil {
+		return err
+	}
+	return nil
 }

--- a/api/impl/id.go
+++ b/api/impl/id.go
@@ -17,7 +17,7 @@ func newNodeID(api *nodeAPI) *nodeID {
 // Details, returns detailed information about the underlying node.
 func (a *nodeID) Details() (*api.IDDetails, error) {
 	host := a.api.node.Host()
-	hostID := host.ID().Pretty()
+	hostID := host.ID()
 	addrs := host.Addrs()
 
 	details := api.IDDetails{
@@ -27,7 +27,7 @@ func (a *nodeID) Details() (*api.IDDetails, error) {
 	}
 
 	for i, addr := range addrs {
-		details.Addresses[i] = fmt.Sprintf("%s/ipfs/%s", addr, hostID)
+		details.Addresses[i] = fmt.Sprintf("%s/ipfs/%s", addr, hostID.Pretty())
 	}
 
 	return &details, nil

--- a/api/impl/id_test.go
+++ b/api/impl/id_test.go
@@ -69,7 +69,7 @@ func TestIdOutput(t *testing.T) {
 	assert.NoError(err)
 
 	// We should have the expected peerID
-	assert.EqualValues(expectedPeerID.Pretty(), actualOut.ID)
+	assert.EqualValues(expectedPeerID, actualOut.ID)
 
 	// Should have expected swarmAddress
 	assert.Contains(actualOut.Addresses[0], fmt.Sprintf("%s/ipfs/%s", expectedSwarm, expectedPeerID.Pretty()))

--- a/commands/id.go
+++ b/commands/id.go
@@ -51,7 +51,7 @@ var idCmd = &cmds.Command{
 
 func idFormatSubstitute(format string, val *api.IDDetails) string {
 	output := format
-	output = strings.Replace(output, "<id>", val.ID, -1)
+	output = strings.Replace(output, "<id>", val.ID.Pretty(), -1)
 	output = strings.Replace(output, "<aver>", val.AgentVersion, -1)
 	output = strings.Replace(output, "<pver>", val.ProtocolVersion, -1)
 	output = strings.Replace(output, "<pubkey>", val.PublicKey, -1)

--- a/tools/fat/action_id.go
+++ b/tools/fat/action_id.go
@@ -2,14 +2,12 @@ package fat
 
 import (
 	"context"
-
 	"github.com/filecoin-project/go-filecoin/api"
 )
 
 // ID runs the `id` command against the filecoin process
 func (f *Filecoin) ID(ctx context.Context, options ...ActionOption) (*api.IDDetails, error) {
 	var out api.IDDetails
-
 	args := []string{"go-filecoin", "id"}
 
 	for _, option := range options {

--- a/tools/fat/process.go
+++ b/tools/fat/process.go
@@ -104,10 +104,7 @@ func (f *Filecoin) StartDaemon(ctx context.Context, wait bool, args ...string) (
 		return nil, err
 	}
 
-	f.PeerID, err = peer.IDB58Decode(idinfo.ID)
-	if err != nil {
-		return nil, err
-	}
+	f.PeerID = idinfo.ID
 
 	return out, nil
 }


### PR DESCRIPTION
See #1743. Note that commands encode the id so FAT has to decode it.

I don't think this is actually the best place to put that decoding–it would be better placed right next to where it's encoded in https://github.com/filecoin-project/go-filecoin/blob/e5afe6e2c8084001997036df0d1b4745d7a86f5a/commands/id.go#L52-L54

⬆️ this reads `val.ID.Pretty()` after the concrete type is introduced.

That would introduce a dep from FAT → commands. Is that ok?

I think this would take the form of a `fromJson` method or similar. I'd be surprised if this hasn't come up before with other output encodings, so is there a pattern somewhere to follow?