### PR TITLE
Vouchers Persistence and Payments Command

### DIFF
--- a/actor/builtin/paymentbroker/payment_voucher.go
+++ b/actor/builtin/paymentbroker/payment_voucher.go
@@ -1,0 +1,49 @@
+package paymentbroker
+
+import (
+	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
+	"gx/ipfs/QmekxXDhCxCJRNuzmHreuaT3BsuJcsjcXWNrtV9C8DRHtd/go-multibase"
+
+	"github.com/filecoin-project/go-filecoin/address"
+	"github.com/filecoin-project/go-filecoin/types"
+)
+
+func init() {
+	cbor.RegisterCborType(PaymentVoucher{})
+}
+
+// PaymentVoucher is a voucher for a payment channel that can be transferred off-chain but guarantees a future payment.
+type PaymentVoucher struct {
+	Channel   types.ChannelID   `json:"channel"`
+	Payer     address.Address   `json:"payer"`
+	Target    address.Address   `json:"target"`
+	Amount    types.AttoFIL     `json:"amount"`
+	ValidAt   types.BlockHeight `json:"valid_at"`
+	Signature types.Signature   `json:"signature"`
+}
+
+// DecodeVoucher creates a *PaymentVoucher from a base58, Cbor-encoded one
+func DecodeVoucher(voucherRaw string) (*PaymentVoucher, error) {
+	_, cborVoucher, err := multibase.Decode(voucherRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	var voucher PaymentVoucher
+	err = cbor.DecodeInto(cborVoucher, &voucher)
+	if err != nil {
+		return nil, err
+	}
+
+	return &voucher, nil
+}
+
+// Encode creates a base58, Cbor-encoded string representation
+func (voucher *PaymentVoucher) Encode() (string, error) {
+	cborVoucher, err := cbor.DumpObject(voucher)
+	if err != nil {
+		return "", err
+	}
+
+	return multibase.Encode(multibase.Base58BTC, cborVoucher)
+}

--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -57,7 +57,6 @@ var Errors = map[uint8]error{
 
 func init() {
 	cbor.RegisterCborType(PaymentChannel{})
-	cbor.RegisterCborType(PaymentVoucher{})
 }
 
 // PaymentChannel records the intent to pay funds to a target account.
@@ -66,16 +65,6 @@ type PaymentChannel struct {
 	Amount         *types.AttoFIL     `json:"amount"`
 	AmountRedeemed *types.AttoFIL     `json:"amount_redeemed"`
 	Eol            *types.BlockHeight `json:"eol"`
-}
-
-// PaymentVoucher is a voucher for a payment channel that can be transferred off-chain but guarantees a future payment.
-type PaymentVoucher struct {
-	Channel   types.ChannelID   `json:"channel"`
-	Payer     address.Address   `json:"payer"`
-	Target    address.Address   `json:"target"`
-	Amount    types.AttoFIL     `json:"amount"`
-	ValidAt   types.BlockHeight `json:"valid_at"`
-	Signature types.Signature   `json:"signature"`
 }
 
 // Actor provides a mechanism for off chain payments.

--- a/api/client.go
+++ b/api/client.go
@@ -8,6 +8,7 @@ import (
 	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	ipld "gx/ipfs/QmcKKBwfz6FyQdHR2jsXrrF6XeSBXYL86anmWNewpFpoF5/go-ipld-format"
 
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
 	"github.com/filecoin-project/go-filecoin/types"
@@ -30,4 +31,5 @@ type Client interface {
 	ProposeStorageDeal(ctx context.Context, data cid.Cid, miner address.Address, ask uint64, duration uint64, allowDuplicates bool) (*storage.DealResponse, error)
 	QueryStorageDeal(ctx context.Context, prop cid.Cid) (*storage.DealResponse, error)
 	ListAsks(ctx context.Context) (<-chan Ask, error)
+	Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error)
 }

--- a/api/impl/client.go
+++ b/api/impl/client.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/filecoin-project/go-filecoin/api"
 	"github.com/filecoin-project/go-filecoin/plumbing/msg"
 
 	imp "gx/ipfs/QmQXze9tG878pa4Euya4rrDpyTNX3kQe4dhCaBzBozGgpe/go-unixfs/importer"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/filecoin-project/go-filecoin/actor"
 	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	mapi "github.com/filecoin-project/go-filecoin/api"
 	"github.com/filecoin-project/go-filecoin/protocol/storage"
@@ -30,6 +32,8 @@ type nodeClient struct {
 func newNodeClient(api *nodeAPI) *nodeClient {
 	return &nodeClient{api: api}
 }
+
+var _ api.Client = &nodeClient{}
 
 func (api *nodeClient) Cat(ctx context.Context, c cid.Cid) (uio.DagReader, error) {
 	// TODO: this goes back to 'how is data stored and referenced'
@@ -120,4 +124,8 @@ func (api *nodeClient) ListAsks(ctx context.Context) (<-chan mapi.Ask, error) {
 	}()
 
 	return out, nil
+}
+
+func (api *nodeClient) Payments(ctx context.Context, dealCid cid.Cid) ([]*paymentbroker.PaymentVoucher, error) {
+	return api.api.node.StorageMinerClient.LoadVouchersForDeal(dealCid)
 }


### PR DESCRIPTION
We create a command, `client payments`, that lists the vouchers associated to a deal. This command also outputs a base58-encoded version of the voucher that can be used for the `redeem` command.

Resolves #1430 