### PR TITLE
add functional flag to faucet test

### DIFF
--- a/functional-tests/faucet_test.go
+++ b/functional-tests/faucet_test.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -19,6 +20,8 @@ import (
 	iptbtester "github.com/filecoin-project/go-filecoin/testhelpers/iptbtester"
 )
 
+var runFunctionalTests = flag.Bool("functional", false, "Run the functional go tests")
+
 var faucetBinary = "../tools/faucet/faucet"
 
 func init() {
@@ -28,6 +31,10 @@ func init() {
 }
 
 func TestFaucetSendFunds(t *testing.T) {
+	// Only run this test if the "-functional" flag is passed to test command
+	if !*runFunctionalTests {
+		t.SkipNow()
+	}
 	assert := assert.New(t)
 	require := require.New(t)
 

--- a/functional-tests/run
+++ b/functional-tests/run
@@ -5,8 +5,10 @@ set -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Go tests
+go test -v "./$(basename $DIR)/..." -functional
+
 # Shell Tests
 . $DIR/retrieval
 
-# Go tests
-go test "./$(basename $DIR)/..."
+


### PR DESCRIPTION
This PR adds a `-functional` flag to run the Faucet tests, said tests will no longer be ran by default for local run; to run the faucet tests the `-functional` flag must be passed to the `go test` command.
closes #1806 