### PR TITLE
Remove `Ls` from the node Chain API and port some tests off it.

### DIFF
--- a/api/chain.go
+++ b/api/chain.go
@@ -1,13 +1,11 @@
 package api
 
 import (
-	"context"
-
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 )
 
 // Chain is the interface that defines methods to inspect the Filecoin blockchain.
+// Deprecated: use the plumbing API instead
 type Chain interface {
 	Head() ([]cid.Cid, error)
-	Ls(ctx context.Context) <-chan interface{}
 }

--- a/api/impl/chain.go
+++ b/api/impl/chain.go
@@ -1,7 +1,6 @@
 package impl
 
 import (
-	"context"
 	"github.com/filecoin-project/go-filecoin/types"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
@@ -28,8 +27,4 @@ func (api *nodeChain) Head() ([]cid.Cid, error) {
 	}
 
 	return out.ToSlice(), nil
-}
-
-func (api *nodeChain) Ls(ctx context.Context) <-chan interface{} {
-	return api.api.node.ChainReader.BlockHistory(ctx)
 }

--- a/api/impl/chain_test.go
+++ b/api/impl/chain_test.go
@@ -2,12 +2,10 @@ package impl
 
 import (
 	"context"
-	"encoding/json"
 	"github.com/filecoin-project/go-filecoin/testhelpers"
 	"testing"
 
 	"github.com/filecoin-project/go-filecoin/chain"
-	"github.com/filecoin-project/go-filecoin/consensus"
 	"github.com/filecoin-project/go-filecoin/node"
 	"github.com/filecoin-project/go-filecoin/types"
 
@@ -80,129 +78,5 @@ func TestChainHead(t *testing.T) {
 
 		assert.Len(out, 3)
 		assert.Equal(sortedCidSet.ToSlice(), out)
-	})
-}
-
-func TestChainLsRun(t *testing.T) {
-	t.Parallel()
-	t.Run("chain of height two", func(t *testing.T) {
-		t.Parallel()
-		require := require.New(t)
-		assert := assert.New(t)
-
-		ctx := context.Background()
-		n := node.MakeOfflineNode(t)
-
-		chainStore, ok := n.ChainReader.(chain.Store)
-		require.True(ok)
-		genBlock, err := consensus.InitGenesis(n.CborStore(), n.Blockstore)
-		require.NoError(err)
-
-		chlBlock := types.NewBlockForTest(genBlock, 1)
-		chlTS := testhelpers.RequireNewTipSet(require, chlBlock)
-		err = chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
-			TipSet:          chlTS,
-			TipSetStateRoot: chlBlock.StateRoot,
-		})
-		require.NoError(err)
-		err = chainStore.SetHead(ctx, chlTS)
-		require.NoError(err)
-
-		api := New(n)
-
-		var bs [][]*types.Block
-		for raw := range api.Chain().Ls(ctx) {
-			switch v := raw.(type) {
-			case consensus.TipSet:
-				bs = append(bs, v.ToSlice())
-			default:
-				assert.FailNow("invalid element in ls", v)
-			}
-		}
-
-		assert.Equal(2, len(bs))
-		types.AssertHaveSameCid(assert, chlBlock, bs[0][0])
-		types.AssertHaveSameCid(assert, genBlock, bs[1][0])
-	})
-
-	t.Run("emit best block and then time out getting parent", func(t *testing.T) {
-		t.Parallel()
-		require := require.New(t)
-
-		ctx := context.Background()
-		n := node.MakeOfflineNode(t)
-
-		parBlock := types.NewBlockForTest(nil, 0)
-		chlBlock := types.NewBlockForTest(parBlock, 1)
-
-		chainStore, ok := n.ChainReader.(chain.Store)
-		require.True(ok)
-		chlTS := testhelpers.RequireNewTipSet(require, chlBlock)
-		err := chainStore.PutTipSetAndState(ctx, &chain.TipSetAndState{
-			TipSet:          chlTS,
-			TipSetStateRoot: chlBlock.StateRoot,
-		})
-		require.NoError(err)
-		err = chainStore.SetHead(ctx, chlTS)
-		require.NoError(err)
-
-		api := New(n)
-		// parBlock is not known to the chain, which causes the timeout
-		var innerErr error
-		for raw := range api.Chain().Ls(ctx) {
-			switch v := raw.(type) {
-			case error:
-				innerErr = v
-			case consensus.TipSet:
-				// ignore
-			default:
-				require.FailNow("invalid element in ls", v)
-			}
-		}
-
-		require.NotNil(innerErr)
-		require.Contains(innerErr.Error(), "failed to get block")
-	})
-
-	t.Run("JSON marshaling", func(t *testing.T) {
-		t.Parallel()
-		assert := assert.New(t)
-
-		parent := types.NewBlockForTest(nil, 0)
-		child := types.NewBlockForTest(parent, 1)
-
-		// Generate a single private/public key pair
-		ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())
-		// Create a mockSigner (bad name) that can sign using the previously generated key
-		mockSigner := types.NewMockSigner(ki)
-		// Generate SignedMessages
-		newSignedMessage := types.NewSignedMessageForTestGetter(mockSigner)
-		message := newSignedMessage()
-
-		retVal := []byte{1, 2, 3}
-		receipt := &types.MessageReceipt{
-			ExitCode: 123,
-			Return:   []types.Bytes{retVal},
-		}
-		child.Messages = []*types.SignedMessage{message}
-		child.MessageReceipts = []*types.MessageReceipt{receipt}
-
-		marshaled, e1 := json.Marshal(child)
-		assert.NoError(e1)
-		str := string(marshaled)
-
-		assert.Contains(str, parent.Cid().String())
-		assert.Contains(str, message.From.String())
-		assert.Contains(str, message.To.String())
-
-		// marshal/unmarshal symmetry
-		var unmarshalled types.Block
-		e2 := json.Unmarshal(marshaled, &unmarshalled)
-		assert.NoError(e2)
-
-		assert.Equal(uint8(123), unmarshalled.MessageReceipts[0].ExitCode)
-		assert.Equal([]types.Bytes{[]byte{1, 2, 3}}, unmarshalled.MessageReceipts[0].Return)
-
-		types.AssertHaveSameCid(assert, child, &unmarshalled)
 	})
 }

--- a/commands/chain.go
+++ b/commands/chain.go
@@ -49,7 +49,7 @@ var chainLsCmd = &cmds.Command{
 		cmdkit.BoolOption("long", "l", "List blocks in long format, including CID, Miner, StateRoot, block height and message count respectively"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
-		for raw := range GetAPI(env).Chain().Ls(req.Context) {
+		for raw := range GetPorcelainAPI(env).ChainLs(req.Context) {
 			switch v := raw.(type) {
 			case error:
 				return v

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -224,7 +224,11 @@ func TestBlockJsonMarshal(t *testing.T) {
 
 	message := newSignedMessage()
 
-	receipt := &MessageReceipt{ExitCode: 0}
+	retVal := []byte{1, 2, 3}
+	receipt := &MessageReceipt{
+		ExitCode: 123,
+		Return:   []Bytes{retVal},
+	}
 	child.Messages = []*SignedMessage{message}
 	child.MessageReceipts = []*MessageReceipt{receipt}
 
@@ -241,5 +245,9 @@ func TestBlockJsonMarshal(t *testing.T) {
 	e2 := json.Unmarshal(marshalled, &unmarshalled)
 	assert.NoError(e2)
 
+	AssertHaveSameCid(assert, &child, &unmarshalled)
 	assert.True(child.Equals(&unmarshalled))
+
+	assert.Equal(uint8(123), unmarshalled.MessageReceipts[0].ExitCode)
+	assert.Equal([]Bytes{[]byte{1, 2, 3}}, unmarshalled.MessageReceipts[0].Return)
 }


### PR DESCRIPTION
This is in support of the goals stated in #1801.