### PR TITLE
#126: add user-devnet build steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,6 +351,50 @@ jobs:
             sudo apt-get install -y curl jq
             curl -X POST --header "Content-Type: application/json" -d '{"branch":"filecoin-nightly"}' https://circleci.com/api/v1.1/project/github/filecoin-project/go-filecoin-infra/build?circle-token=$CIRCLE_API_TOKEN
 
+  trigger_user_devnet_deploy:
+    docker:
+      - image: circleci/golang:latest
+    resource_class: small
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run:
+          name: Install AWS CLI
+          command: |
+            sudo apt-get install -y python-pip libyaml-dev python-dev jq
+            sudo pip install awscli
+      - run:
+          name: login to ECR
+          command: |
+            export AWS_ACCESS_KEY_ID=$AWS_ECR_ACCESS_KEY_ID
+            export AWS_SECRET_ACCESS_KEY=$AWS_ECR_SECRET_ACCESS_KEY
+            eval $(aws --region us-east-1 ecr --no-include-email get-login)
+      - run:
+          name: Tag filecoin image with devnet-user
+          command: |
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker pull 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:devnet-user
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin:devnet-user
+      - run:
+          name: Tag filecoin-faucet image with devnet-user
+          command: |
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker pull 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:devnet-user
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-faucet:devnet-user
+      - run:
+          name: Tag filecoin-genesis-file-server image with devnet-user
+          command: |
+            export SHORT_GIT_SHA=$(echo $CIRCLE_SHA1 | cut -c -6)
+            docker pull 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA
+            docker tag 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:$SHORT_GIT_SHA 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:devnet-user
+            docker push 657871693752.dkr.ecr.us-east-1.amazonaws.com/filecoin-genesis-file-server:devnet-user
+      - run:
+          name: Trigger user deploy in go-filecoin-infra
+          command: |
+            sudo apt-get install -y curl jq
+            curl -X POST --header "Content-Type: application/json" -d '{"branch":"filecoin-usernet"}' https://circleci.com/api/v1.1/project/github/filecoin-project/go-filecoin-infra/build?circle-token=$CIRCLE_API_TOKEN
 
 workflows:
   version: 2
@@ -424,3 +468,34 @@ workflows:
       - trigger_nightly_devnet_deploy:
           requires:
             - build_docker_img
+
+  build_user_devnet:
+    jobs:
+      - build_linux:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^devnet-user$/
+      - build_docker_img:
+          requires:
+            - build_linux
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^devnet-user$/
+      - trigger_user_devnet_deploy:
+          requires:
+            - build_docker_img
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^devnet-user$/


### PR DESCRIPTION
- add CircleCI steps for building from `devnet-user` tag
- tag docker images with `devnet-user`
- trigger a re-deploy of `user.kittyhawk.wtf` via remote build in `go-filecoin-infra`