### PR TITLE
Miners validate deal PaymentInfo

### DIFF
--- a/actor/builtin/paymentbroker/paymentbroker.go
+++ b/actor/builtin/paymentbroker/paymentbroker.go
@@ -187,8 +187,7 @@ func (pb *Actor) Redeem(vmctx exec.VMContext, payer address.Address, chid *types
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
 
-	data := createVoucherSignatureData(chid, amt, validAt)
-	if !types.IsValidSignature(data, payer, sig) {
+	if !VerifyVoucherSignature(payer, chid, amt, validAt, sig) {
 		return errors.CodeError(Errors[ErrInvalidSignature]), Errors[ErrInvalidSignature]
 	}
 
@@ -238,8 +237,7 @@ func (pb *Actor) Close(vmctx exec.VMContext, payer address.Address, chid *types.
 		return exec.ErrInsufficientGas, errors.RevertErrorWrap(err, "Insufficient gas")
 	}
 
-	data := createVoucherSignatureData(chid, amt, validAt)
-	if !types.IsValidSignature(data, payer, sig) {
+	if !VerifyVoucherSignature(payer, chid, amt, validAt, sig) {
 		return errors.CodeError(Errors[ErrInvalidSignature]), Errors[ErrInvalidSignature]
 	}
 
@@ -554,6 +552,12 @@ const separator = 0x0
 func SignVoucher(channelID *types.ChannelID, amount *types.AttoFIL, validAt *types.BlockHeight, addr address.Address, signer types.Signer) (types.Signature, error) {
 	data := createVoucherSignatureData(channelID, amount, validAt)
 	return signer.SignBytes(data, addr)
+}
+
+// VerifyVoucherSignature returns whether the voucher's signature is valid
+func VerifyVoucherSignature(payer address.Address, chid *types.ChannelID, amt *types.AttoFIL, validAt *types.BlockHeight, sig []byte) bool {
+	data := createVoucherSignatureData(chid, amt, validAt)
+	return types.IsValidSignature(data, payer, sig)
 }
 
 func createVoucherSignatureData(channelID *types.ChannelID, amount *types.AttoFIL, validAt *types.BlockHeight) []byte {

--- a/chain/get_ancestors.go
+++ b/chain/get_ancestors.go
@@ -36,8 +36,8 @@ func GetRecentAncestors(ctx context.Context, base types.TipSet, chainReader Read
 	if lookback == 0 {
 		return nil, errors.New("lookback must be greater than 0")
 	}
-	earliestAncestorHeight, err := childBH.Sub(ancestorRoundsNeeded)
-	if err != nil {
+	earliestAncestorHeight := childBH.Sub(ancestorRoundsNeeded)
+	if earliestAncestorHeight.LessThan(types.NewBlockHeight(0)) {
 		earliestAncestorHeight = types.NewBlockHeight(uint64(0))
 	}
 	historyCh := chainReader.BlockHistory(ctx, base)

--- a/commands/payment_channel_daemon_test.go
+++ b/commands/payment_channel_daemon_test.go
@@ -268,6 +268,7 @@ func TestPaymentChannelCloseSuccess(t *testing.T) {
 	// Initial Balance 10,000,000
 	payerA, err := address.NewFromString(fixtures.TestAddresses[0])
 	require.NoError(err)
+
 	// Initial Balance 10,000,000
 	targetA, err := address.NewFromString(fixtures.TestAddresses[1])
 	require.NoError(err)

--- a/plumbing/api.go
+++ b/plumbing/api.go
@@ -141,6 +141,11 @@ func (api *API) NetworkGetPeerID() peer.ID {
 	return api.network.GetPeerID()
 }
 
+// SignBytes uses private key information associated with the given address to sign the given bytes.
+func (api *API) SignBytes(data []byte, addr address.Address) (types.Signature, error) {
+	return api.wallet.SignBytes(data, addr)
+}
+
 // WalletAddresses gets addresses from the wallet
 func (api *API) WalletAddresses() []address.Address {
 	return api.wallet.Addresses()

--- a/protocol/storage/client_test.go
+++ b/protocol/storage/client_test.go
@@ -84,7 +84,7 @@ func TestProposeDeal(t *testing.T) {
 	t.Run("and creates a new payment channel", func(t *testing.T) {
 		// correct payment id and message cid in proposal implies a call to createChannel
 		assert.Equal(testAPI.channelID, proposal.Payment.Channel)
-		assert.Equal(testAPI.msgCid.String(), proposal.Payment.ChannelMsgCid)
+		assert.Equal(&testAPI.msgCid, proposal.Payment.ChannelMsgCid)
 	})
 
 	t.Run("and creates payment info", func(t *testing.T) {
@@ -193,7 +193,7 @@ func (ctp *clientTestAPI) MinerGetPeerID(ctx context.Context, minerAddr address.
 	return id, nil
 }
 
-func (ctp *clientTestAPI) ConfigGet(dottedPath string) (interface{}, error) {
+func (ctp *clientTestAPI) GetAndMaybeSetDefaultSenderAddress() (address.Address, error) {
 	// always just default address
 	return ctp.payer, nil
 }

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -7,6 +7,8 @@ import (
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
+	"github.com/filecoin-project/go-filecoin/actor"
+	"github.com/filecoin-project/go-filecoin/actor/builtin/paymentbroker"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/exec"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
@@ -17,32 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type minerTestPorcelain struct {
-	config *cfg.Config
-}
-
-func newMinerTestPorcelain() *minerTestPorcelain {
-	return &minerTestPorcelain{
-		config: cfg.NewConfig(repo.NewInMemoryRepo()),
-	}
-}
-
-func (mtp *minerTestPorcelain) MessageSendWithRetry(ctx context.Context, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) error {
-	return nil
-}
-
-func (mtp *minerTestPorcelain) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
-	return [][]byte{}, nil, nil
-}
-
-func (mtp *minerTestPorcelain) ConfigGet(dottedPath string) (interface{}, error) {
-	return mtp.config.Get(dottedPath)
-}
-
-func (mtp *minerTestPorcelain) ConfigSet(dottedKey string, jsonString string) error {
-	return mtp.config.Set(dottedKey, jsonString)
-}
-
 func TestReceiveStorageProposal(t *testing.T) {
 	t.Run("Accepts proposals with sufficient TotalPrice", func(t *testing.T) {
 		assert := assert.New(t)
@@ -50,68 +26,161 @@ func TestReceiveStorageProposal(t *testing.T) {
 
 		accepted := false
 		rejected := false
+		var message string
 
 		porcelainAPI := newMinerTestPorcelain()
 		miner := Miner{
-			porcelainAPI: porcelainAPI,
+			porcelainAPI:   porcelainAPI,
+			minerOwnerAddr: porcelainAPI.targetAddress,
 			proposalAcceptor: func(ctx context.Context, m *Miner, p *DealProposal) (*DealResponse, error) {
 				accepted = true
-				return &DealResponse{}, nil
+				return &DealResponse{State: Accepted}, nil
 			},
 			proposalRejector: func(ctx context.Context, m *Miner, p *DealProposal, reason string) (*DealResponse, error) {
+				message = reason
 				rejected = true
-				return &DealResponse{Message: reason}, nil
+				return &DealResponse{State: Rejected, Message: reason}, nil
 			},
 		}
 
-		// configure storage price
-		porcelainAPI.config.Set("mining.storagePrice", `"50"`)
-
-		proposal := &DealProposal{
-			TotalPrice: types.NewAttoFILFromFIL(75),
-		}
+		proposal := testDealProposal(porcelainAPI, VoucherInterval, 1773, porcelainAPI.targetAddress)
 
 		_, err := miner.receiveStorageProposal(context.Background(), proposal)
 		require.NoError(err)
 
 		assert.True(accepted, "Proposal has been accepted")
 		assert.False(rejected, "Proposal has not been rejected")
+		assert.Equal("", message)
 	})
 
 	t.Run("Rejects proposals with insufficient TotalPrice", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
 
-		accepted := false
-		rejected := false
-
-		porcelainAPI := newMinerTestPorcelain()
-		miner := Miner{
-			porcelainAPI: porcelainAPI,
-			proposalAcceptor: func(ctx context.Context, m *Miner, p *DealProposal) (*DealResponse, error) {
-				accepted = true
-				return &DealResponse{}, nil
-			},
-			proposalRejector: func(ctx context.Context, m *Miner, p *DealProposal, reason string) (*DealResponse, error) {
-				rejected = true
-				return &DealResponse{Message: reason}, nil
-			},
-		}
+		porcelainAPI, miner, proposal := newMinerTestSetup()
 
 		// configure storage price
-		porcelainAPI.config.Set("mining.storagePrice", `"50"`)
-
-		proposal := &DealProposal{
-			TotalPrice: types.NewAttoFILFromFIL(25),
-		}
+		porcelainAPI.config.Set("mining.storagePrice", `".0005"`)
 
 		res, err := miner.receiveStorageProposal(context.Background(), proposal)
 		require.NoError(err)
 
-		assert.False(accepted, "Proposal has not been accepted")
-		assert.True(rejected, "Proposal has been rejected")
+		assert.Equal(Rejected, res.State)
+		assert.Equal("proposed price (2500) is less than expected (5000) given asking price of 0.0005", res.Message)
+	})
 
-		assert.Equal("proposed price 25 is less that miner's current asking price: 50", res.Message)
+	t.Run("Rejects proposals with invalid payment channel", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		porcelainAPI, miner, proposal := newMinerTestSetup()
+		porcelainAPI.noChannels = true
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "could not find payment channel")
+	})
+
+	t.Run("Rejects proposals with wrong target", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		_, miner, proposal := newMinerTestSetup()
+		miner.minerOwnerAddr = address.TestAddress
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "not target of payment channel")
+	})
+
+	t.Run("Rejects proposals with too short channel eol", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		porcelainAPI, miner, proposal := newMinerTestSetup()
+		porcelainAPI.channelEol = types.NewBlockHeight(1200)
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "less than required eol")
+	})
+
+	t.Run("Rejects proposals with no payments", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		_, miner, proposal := newMinerTestSetup()
+		proposal.Payment.Vouchers = []*paymentbroker.PaymentVoucher{}
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "contains no payment vouchers")
+	})
+
+	t.Run("Rejects proposals with vouchers with invalid signatures", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		_, miner, proposal := newMinerTestSetup()
+		proposal.Payment.Vouchers[0].Signature = types.Signature([]byte{})
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "invalid signature in voucher")
+	})
+
+	t.Run("Rejects proposals with when payments start too late", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		porcelainAPI, miner, _ := newMinerTestSetup()
+		porcelainAPI.paymentStart = porcelainAPI.paymentStart.Add(types.NewBlockHeight(15))
+		proposal := testDealProposal(porcelainAPI, VoucherInterval, 1773, porcelainAPI.targetAddress)
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "payments start after deal start interval")
+	})
+
+	t.Run("Rejects proposals with vouchers with long intervals", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		porcelainAPI, miner, _ := newMinerTestSetup()
+		porcelainAPI.paymentStart = porcelainAPI.paymentStart.Sub(types.NewBlockHeight(15))
+		proposal := testDealProposal(porcelainAPI, VoucherInterval+15, 1773, porcelainAPI.targetAddress)
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "interval between vouchers")
+	})
+
+	t.Run("Rejects proposals with vouchers with insufficient amounts", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		porcelainAPI, miner, _ := newMinerTestSetup()
+		proposal := testDealProposal(porcelainAPI, VoucherInterval, 1, porcelainAPI.targetAddress)
+
+		res, err := miner.receiveStorageProposal(context.Background(), proposal)
+		require.NoError(err)
+
+		assert.Equal(Rejected, res.State)
+		assert.Contains(res.Message, "voucher amount")
 	})
 }
 
@@ -241,4 +310,136 @@ func TestDealsAwaitingSeal(t *testing.T) {
 
 		assert.Len(gotCids, 1, "onFail should've been called once")
 	})
+}
+
+type minerTestPorcelain struct {
+	config        *cfg.Config
+	payerAddress  address.Address
+	targetAddress address.Address
+	channelID     *types.ChannelID
+	messageCid    *cid.Cid
+	signer        types.MockSigner
+	noChannels    bool
+	blockHeight   *types.BlockHeight
+	channelEol    *types.BlockHeight
+	paymentStart  *types.BlockHeight
+}
+
+func newMinerTestPorcelain() *minerTestPorcelain {
+	ki := types.MustGenerateKeyInfo(1, types.GenerateKeyInfoSeed())
+	mockSigner := types.NewMockSigner(ki)
+	payerAddr, err := ki[0].Address()
+	if err != nil {
+		panic("Could not create payer address")
+	}
+
+	addressGetter := address.NewForTestGetter()
+	cidGetter := types.NewCidForTestGetter()
+
+	cid := cidGetter()
+
+	config := cfg.NewConfig(repo.NewInMemoryRepo())
+	config.Set("mining.storagePrice", `".00025"`)
+
+	blockHeight := types.NewBlockHeight(773)
+	return &minerTestPorcelain{
+		config:        config,
+		payerAddress:  payerAddr,
+		targetAddress: addressGetter(),
+		channelID:     types.NewChannelID(73),
+		messageCid:    &cid,
+		signer:        mockSigner,
+		noChannels:    false,
+		channelEol:    types.NewBlockHeight(13773),
+		blockHeight:   blockHeight,
+		paymentStart:  blockHeight,
+	}
+}
+
+func (mtp *minerTestPorcelain) MessageSendWithRetry(ctx context.Context, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) error {
+	return nil
+}
+
+func (mtp *minerTestPorcelain) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {
+	channels := map[string]*paymentbroker.PaymentChannel{}
+
+	if !mtp.noChannels {
+		id := mtp.channelID.KeyString()
+		channels[id] = &paymentbroker.PaymentChannel{
+			Target:         mtp.targetAddress,
+			Amount:         types.NewAttoFILFromFIL(100000),
+			AmountRedeemed: types.NewAttoFILFromFIL(0),
+			Eol:            mtp.channelEol,
+		}
+	}
+
+	channelsBytes, err := actor.MarshalStorage(channels)
+	if err != nil {
+		panic(err)
+	}
+	return [][]byte{channelsBytes}, nil, nil
+}
+
+func (mtp *minerTestPorcelain) ConfigGet(dottedPath string) (interface{}, error) {
+	return mtp.config.Get(dottedPath)
+}
+
+func (mtp *minerTestPorcelain) ChainBlockHeight(ctx context.Context) (*types.BlockHeight, error) {
+	return mtp.blockHeight, nil
+}
+
+func (mtp *minerTestPorcelain) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
+	return nil
+}
+
+func newTestMiner(api *minerTestPorcelain) *Miner {
+	return &Miner{
+		porcelainAPI:   api,
+		minerOwnerAddr: api.targetAddress,
+		proposalAcceptor: func(ctx context.Context, m *Miner, p *DealProposal) (*DealResponse, error) {
+			return &DealResponse{State: Accepted}, nil
+		},
+		proposalRejector: func(ctx context.Context, m *Miner, p *DealProposal, reason string) (*DealResponse, error) {
+			return &DealResponse{State: Rejected, Message: reason}, nil
+		},
+	}
+}
+
+func newMinerTestSetup() (*minerTestPorcelain, *Miner, *DealProposal) {
+	porcelainAPI := newMinerTestPorcelain()
+	return porcelainAPI, newTestMiner(porcelainAPI), testDealProposal(porcelainAPI, VoucherInterval, 1773, porcelainAPI.targetAddress)
+}
+
+func testDealProposal(porcelainAPI *minerTestPorcelain, voucherInterval int, amountInc uint64, addr address.Address) *DealProposal {
+	vouchers := make([]*paymentbroker.PaymentVoucher, 10)
+
+	for i := 0; i < 10; i++ {
+		validAt := porcelainAPI.paymentStart.Add(types.NewBlockHeight(uint64((i + 1) * voucherInterval)))
+		amount := types.NewAttoFILFromFIL(uint64(i+1) * amountInc)
+		signature, err := paymentbroker.SignVoucher(porcelainAPI.channelID, amount, validAt, porcelainAPI.payerAddress, porcelainAPI.signer)
+		if err != nil {
+			panic("Could not sign valid proposal")
+		}
+		vouchers[i] = &paymentbroker.PaymentVoucher{
+			Channel:   *porcelainAPI.channelID,
+			Payer:     porcelainAPI.payerAddress,
+			Target:    porcelainAPI.targetAddress,
+			Amount:    *amount,
+			ValidAt:   *validAt,
+			Signature: signature,
+		}
+	}
+
+	return &DealProposal{
+		TotalPrice: types.NewAttoFILFromFIL(2500),
+		Size:       types.NewBytesAmount(1000),
+		Duration:   10000,
+		Payment: PaymentInfo{
+			Payer:         porcelainAPI.payerAddress,
+			PayChActor:    address.PaymentBrokerAddress,
+			Channel:       porcelainAPI.channelID,
+			ChannelMsgCid: porcelainAPI.messageCid,
+			Vouchers:      vouchers,
+		},
+	}
 }

--- a/protocol/storage/storage_protocol_test.go
+++ b/protocol/storage/storage_protocol_test.go
@@ -22,7 +22,8 @@ func TestSerializeProposal(t *testing.T) {
 	cg := types.NewCidForTestGetter()
 	p := &DealProposal{}
 	p.Size = types.NewBytesAmount(5)
-	p.Payment.ChannelMsgCid = cg().String()
+	cmc := cg()
+	p.Payment.ChannelMsgCid = &cmc
 	p.Payment.Channel = types.NewChannelID(4)
 	voucher := &paymentbroker.PaymentVoucher{
 		Channel:   *types.NewChannelID(4),

--- a/protocol/storage/types.go
+++ b/protocol/storage/types.go
@@ -23,12 +23,15 @@ type PaymentInfo struct {
 	// that will be used to facilitate payments
 	PayChActor address.Address
 
+	// Payer is the address of the owner of the payment channel
+	Payer address.Address
+
 	// Channel is the ID of the specific channel the client will
 	// use to pay the miner. It must already have sufficient funds locked up
 	Channel *types.ChannelID
 
 	// ChannelMsgCid is the B58 encoded CID of the message used to create the channel (so the miner can wait for it).
-	ChannelMsgCid string
+	ChannelMsgCid *cid.Cid
 
 	// Vouchers is a set of payments from the client to the miner that can be
 	// cashed out contingent on the agreed upon data being provably within a

--- a/types/block_height.go
+++ b/types/block_height.go
@@ -6,7 +6,6 @@ import (
 
 	cbor "gx/ipfs/QmRoARq3nkUb13HSKZGepCZSWe5GrVPwx7xURJGZ7KWv9V/go-ipld-cbor"
 	"gx/ipfs/QmSKyB5faguXT4NqbrXpnRXqaVj5DhSm7x9BtzFydBY1UK/go-leb128"
-	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 	"gx/ipfs/QmfWqohMtbivn5NRJvtrLzCW3EU4QmoLvVNtmvo9vbdtVA/refmt/obj/atlas"
 )
 
@@ -112,11 +111,13 @@ func (z *BlockHeight) Add(y *BlockHeight) *BlockHeight {
 }
 
 // Sub subtracts y from a copy of z and returns the copy.
-func (z *BlockHeight) Sub(y *BlockHeight) (*BlockHeight, error) {
-	if z.LessThan(y) {
-		return nil, errors.New("difference is negative cannot create negative block height")
-	}
+func (z *BlockHeight) Sub(y *BlockHeight) *BlockHeight {
 	a := big.NewInt(0).Set(z.val)
 	a = a.Sub(a, y.val)
-	return &BlockHeight{val: a}, nil
+	return &BlockHeight{val: a}
+}
+
+// AsBigInt returns the blockheight as a big.Int
+func (z *BlockHeight) AsBigInt() *big.Int {
+	return z.val
 }


### PR DESCRIPTION
closes #1432

### Problem

Storage clients are now automatically generating payment for storage deals as part #1775. Miners should not validate that information as part of the storage protocol.

### Solution

Add validate method to protocol miner. This validates:

* Payment channel exists
* Miner is target of channel
* Channel contains funds for the full execution of the deal
* The first payment's `ValidAt` is not greater than a `VoucherInterval` past the current block height
* The `ValidAt` of each payment is no more than `VoucherInterval` past the previous payment
* The payment values should be uniformly distributed across the payments. Specifically, the amount of each payment is no less than the total amount times the fraction of the duration represented by the payments duration.
* The last voucher allows the miner to collect all the funds for the deal
* Channel expires after at least `ChannelExpiryInterval` past the last payment

### Note

Implementation of validation exposed some omissions in creating the payments. Notably that we weren't signing vouchers. This PR address that as well. This is why we need the `SignBytes` plumbing call.
