### PR TITLE
Bug/race in commit sector retry

### DIFF
--- a/consensus/processor.go
+++ b/consensus/processor.go
@@ -283,7 +283,7 @@ func (p *DefaultProcessor) ApplyMessage(ctx context.Context, st state.Tree, vms 
 		// includes errInsufficientFunds because we don't want the message
 		// to be replayable.
 		executionError = err
-		log.Warningf("ApplyMessage execution error: %s", executionError)
+		log.Infof("ApplyMessage failed: %s %s", executionError, msg.String())
 	}
 
 	// At this point we consider the message successfully applied so inc

--- a/node/node.go
+++ b/node/node.go
@@ -832,19 +832,16 @@ func (node *Node) StartMining(ctx context.Context) error {
 					gasUnits := types.BlockGasLimit
 
 					val := result.SealingResult
-					// This call can fail due to, e.g. nonce collisions, so we retry to make sure we include it,
-					// as our miners existence depends on this.
-					err := porcelain.MessageSendWithRetry(
+					// This call can fail due to, e.g. nonce collisions. Our miners existence depends on this.
+					// We should deal with this, but MessageSendWithRetry is problematic.
+					_, err := node.PorcelainAPI.MessageSend(
 						node.miningCtx,
-						node.PorcelainAPI,
-						10,                  /* retries */
-						node.GetBlockTime(), /* wait per retry */
 						minerOwnerAddr,
 						minerAddr,
 						nil,
-						"commitSector",
 						gasPrice,
 						gasUnits,
+						"commitSector",
 						val.SectorID,
 						val.CommD[:],
 						val.CommR[:],

--- a/porcelain/api.go
+++ b/porcelain/api.go
@@ -3,7 +3,6 @@ package porcelain
 import (
 	"context"
 	"math/big"
-	"time"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmY5Grm8pJdiSSVsYxx4uNRgweY72EmYwuSDbRnbFok3iY/go-libp2p-peer"
@@ -50,23 +49,6 @@ func (a *API) ChainBlockHeight(ctx context.Context) (*types.BlockHeight, error) 
 // CreatePayments establishes a payment channel and create multiple payments against it
 func (a *API) CreatePayments(ctx context.Context, config CreatePaymentsParams) (*CreatePaymentsReturn, error) {
 	return CreatePayments(ctx, a, config)
-}
-
-// MessageSendWithRetry sends a message and retries if it does not appear on chain. See implementation
-// for more details.
-func (a *API) MessageSendWithRetry(
-	ctx context.Context,
-	numRetries uint,
-	waitDuration time.Duration,
-	from,
-	to address.Address,
-	val *types.AttoFIL,
-	method string,
-	gasPrice types.AttoFIL,
-	gasLimit types.GasUnits,
-	params ...interface{},
-) (err error) {
-	return MessageSendWithRetry(ctx, a, numRetries, waitDuration, from, to, val, method, gasPrice, gasLimit, params...)
 }
 
 // MessageSendWithDefaultAddress calls MessageSend but with a default from

--- a/porcelain/message.go
+++ b/porcelain/message.go
@@ -2,88 +2,18 @@ package porcelain
 
 import (
 	"context"
-	"time"
-
-	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
+	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 	"gx/ipfs/QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy/errors"
 	logging "gx/ipfs/QmcuXC5cxs79ro2cUuHs4HQ2bkDLJUYokwL8aivcX6HW3C/go-log"
 
-	"github.com/filecoin-project/go-filecoin/actor/builtin/miner"
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/types"
-	vmErrors "github.com/filecoin-project/go-filecoin/vm/errors"
 )
 
 // ErrNoDefaultFromAddress is returned when a default address to send from couldn't be determined (eg, there are zero addresses in the wallet).
 var ErrNoDefaultFromAddress = errors.New("unable to determine a default address to send the message from")
 
-// mswrAPI is the subset of the plumbing.API that MessageSendWithRetry uses.
-type mswrAPI interface {
-	MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
-	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
-}
-
 var log = logging.Logger("porcelain") // nolint: deadcode
-
-// MessageSendWithRetry sends a message and retries if it does not appear on chain. It returns
-// an error if it maxes out its retries, if the message on chain has an error receipt, or if
-// it hits an unexpected error.
-//
-// Note: this is not an awesome retry pattern because:
-// - the message could be successfully sent twice eg if attempt 1 appears to fail
-//   we will stop waiting for it and attempt a second send. If the first attempt
-//   succeeds we don't see it and continue to retry the second.
-// - it spams the network with re-tries and doesn't clean up the message pool with
-//   attempts that have been abandoned.
-// - it's hard to know how long to wait given the potential for null blocks
-// - it spends a lot of time walking back in the chain for a message that will not be there.
-//   We don't have a mechanism to just wait on future messages or to limit the walk-back.
-//
-// Access to failures might make this a little better but really the solution is
-// to not have re-tries, eg if we had nonce lanes.
-func MessageSendWithRetry(ctx context.Context, plumbing mswrAPI, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) (err error) {
-	for i := 0; i < int(numRetries); i++ {
-		log.Debugf("SendMessageAndWait (%s) retry %d/%d, waitDuration %v", method, i, numRetries, waitDuration)
-
-		if err = ctx.Err(); err != nil {
-			return
-		}
-
-		msgCid, err := plumbing.MessageSendWithDefaultAddress(
-			ctx,
-			from,
-			to,
-			val,
-			gasPrice,
-			gasLimit,
-			method,
-			params...,
-		)
-		if err != nil {
-			return errors.Wrap(err, "couldn't send message")
-		}
-
-		waitCtx, waitCancel := context.WithDeadline(ctx, time.Now().Add(waitDuration))
-		found := false
-		err = plumbing.MessageWait(waitCtx, msgCid, func(blk *types.Block, smsg *types.SignedMessage, receipt *types.MessageReceipt) error {
-			found = true
-			if receipt.ExitCode != uint8(0) {
-				return vmErrors.VMExitCodeToError(receipt.ExitCode, miner.Errors)
-			}
-			return nil
-		})
-		waitCancel()
-		if err != nil && err != context.DeadlineExceeded {
-			return errors.Wrap(err, "got an error from MessageWait")
-		} else if found {
-			return nil
-		}
-		// TODO should probably remove the old message from the message queue?
-		// TODO could keep a list of preivous message cids in case one of them shows up.
-	}
-
-	return errors.Wrapf(err, "failed to send message after waiting %v for each of %d retries ", waitDuration, numRetries)
-}
 
 // mswdaAPI is the subset of the plumbing.API that MessageSendWithDefaultAddress uses.
 type mswdaAPI interface {

--- a/porcelain/message_test.go
+++ b/porcelain/message_test.go
@@ -1,119 +1,16 @@
 package porcelain_test
 
 import (
-	"context"
 	"testing"
-	"time"
-
-	cid "gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
 	"github.com/filecoin-project/go-filecoin/address"
 	"github.com/filecoin-project/go-filecoin/plumbing/cfg"
 	"github.com/filecoin-project/go-filecoin/porcelain"
 	"github.com/filecoin-project/go-filecoin/repo"
-	"github.com/filecoin-project/go-filecoin/types"
 	"github.com/filecoin-project/go-filecoin/wallet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var newCid = types.NewCidForTestGetter()
-var newAddr = address.NewForTestGetter()
-
-type fakeMessageSendWithRetryPlumbing struct {
-	assert  *assert.Assertions
-	require *require.Assertions
-
-	msgCid  cid.Cid
-	sendCnt int
-
-	messageSend func(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
-	messageWait func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
-}
-
-func (fp *fakeMessageSendWithRetryPlumbing) MessageSendWithDefaultAddress(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
-	return fp.messageSend(ctx, from, to, value, gasPrice, gasLimit, method, params...)
-}
-
-func (fp *fakeMessageSendWithRetryPlumbing) MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
-	return fp.messageWait(ctx, msgCid, cb)
-}
-
-// Fake implementations we'll use.
-func (fp *fakeMessageSendWithRetryPlumbing) successfulMessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
-	fp.msgCid = newCid()
-	fp.sendCnt++
-	return fp.msgCid, nil
-}
-
-func (fp *fakeMessageSendWithRetryPlumbing) successfulMessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
-	fp.require.NotEqual(cid.Undef, fp.msgCid)
-	fp.assert.True(fp.msgCid.Equals(msgCid))
-	cb(&types.Block{}, &types.SignedMessage{}, &types.MessageReceipt{ExitCode: 0, Return: []types.Bytes{}})
-	return nil
-}
-
-func (fp *fakeMessageSendWithRetryPlumbing) unsuccessfulMessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
-	fp.require.NotEqual(cid.Undef, fp.msgCid)
-	fp.assert.True(fp.msgCid.Equals(msgCid))
-	return context.DeadlineExceeded
-}
-
-func TestMessageSendWithRetry(t *testing.T) {
-	t.Parallel()
-	val, gasPrice, gasLimit := types.NewAttoFILFromFIL(0), types.NewGasPrice(0), types.NewGasUnits(0)
-
-	t.Run("succeeds on first try", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		ctx := context.Background()
-		from, to := newAddr(), newAddr()
-
-		fp := &fakeMessageSendWithRetryPlumbing{assert: assert, require: require}
-		fp.messageSend = fp.successfulMessageSend
-		fp.messageWait = fp.successfulMessageWait
-
-		err := porcelain.MessageSendWithRetry(ctx, fp, 10 /* retries */, 1*time.Second /* wait time*/, from, to, val, "", gasPrice, gasLimit)
-		require.NoError(err)
-		assert.Equal(1, fp.sendCnt)
-	})
-
-	t.Run("retries if not successful", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		ctx := context.Background()
-		from, to := newAddr(), newAddr()
-
-		fp := &fakeMessageSendWithRetryPlumbing{assert: assert, require: require}
-		fp.messageSend = fp.successfulMessageSend
-		fp.messageWait = fp.unsuccessfulMessageWait
-
-		err := porcelain.MessageSendWithRetry(ctx, fp, 10 /* retries */, 1*time.Second /* wait time*/, from, to, val, "", gasPrice, gasLimit)
-		require.NoError(err)
-		assert.Equal(10, fp.sendCnt)
-	})
-
-	t.Run("respects top-level context", func(t *testing.T) {
-		require := require.New(t)
-		assert := assert.New(t)
-		ctx, cancel := context.WithCancel(context.Background())
-		from, to := newAddr(), newAddr()
-
-		fp := &fakeMessageSendWithRetryPlumbing{assert: assert, require: require}
-		fp.messageSend = fp.successfulMessageSend
-		// This MessageWait cancels and ctx and returns unsuccessfully. The effect is
-		// canceling the global context during the first run; we expect it not to retry
-		// if that is the case ie sendCnt to be 1.
-		fp.messageWait = func(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error {
-			cancel()
-			return nil
-		}
-
-		err := porcelain.MessageSendWithRetry(ctx, fp, 10 /* retries */, 1*time.Second /* wait time*/, from, to, val, "", gasPrice, gasLimit)
-		require.Error(err)
-		assert.Equal(1, fp.sendCnt)
-	})
-}
 
 type fakeGetAndMaybeSetDefaultSenderAddressPlumbing struct {
 	config *cfg.Config

--- a/protocol/storage/miner.go
+++ b/protocol/storage/miner.go
@@ -83,7 +83,7 @@ type minerPorcelain interface {
 	ChainBlockHeight(ctx context.Context) (*types.BlockHeight, error)
 	ConfigGet(dottedPath string) (interface{}, error)
 
-	MessageSendWithRetry(ctx context.Context, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) error
+	MessageSend(ctx context.Context, from, to address.Address, value *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error)
 	MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error)
 	MessageWait(ctx context.Context, msgCid cid.Cid, cb func(*types.Block, *types.SignedMessage, *types.MessageReceipt) error) error
 }
@@ -776,7 +776,7 @@ func (sm *Miner) submitPoSt(start, end *types.BlockHeight, inputs []generatePost
 	gasPrice := types.NewGasPrice(submitPostGasPrice)
 	gasLimit := types.NewGasUnits(submitPostGasLimit)
 
-	err = sm.porcelainAPI.MessageSendWithRetry(ctx, 10 /*retries*/, sm.node.GetBlockTime() /*wait time*/, sm.minerOwnerAddr, sm.minerAddr, types.NewAttoFIL(big.NewInt(0)), "submitPoSt", gasPrice, gasLimit, proof[:])
+	_, err = sm.porcelainAPI.MessageSend(ctx, sm.minerOwnerAddr, sm.minerAddr, types.ZeroAttoFIL, gasPrice, gasLimit, "submitPoSt", proof[:])
 	if err != nil {
 		log.Errorf("failed to submit PoSt: %s", err)
 		return

--- a/protocol/storage/miner_test.go
+++ b/protocol/storage/miner_test.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"testing"
-	"time"
 
 	"gx/ipfs/QmR8BauakNcBa3RbE4nbQu76PDiJgoQgz8AJdhJuiU4TAw/go-cid"
 
@@ -356,8 +355,8 @@ func newMinerTestPorcelain() *minerTestPorcelain {
 	}
 }
 
-func (mtp *minerTestPorcelain) MessageSendWithRetry(ctx context.Context, numRetries uint, waitDuration time.Duration, from, to address.Address, val *types.AttoFIL, method string, gasPrice types.AttoFIL, gasLimit types.GasUnits, params ...interface{}) error {
-	return nil
+func (mtp *minerTestPorcelain) MessageSend(ctx context.Context, from, to address.Address, val *types.AttoFIL, gasPrice types.AttoFIL, gasLimit types.GasUnits, method string, params ...interface{}) (cid.Cid, error) {
+	return cid.Cid{}, nil
 }
 
 func (mtp *minerTestPorcelain) MessageQuery(ctx context.Context, optFrom, to address.Address, method string, params ...interface{}) ([][]byte, *exec.FunctionSignature, error) {

--- a/testhelpers/commands.go
+++ b/testhelpers/commands.go
@@ -390,7 +390,9 @@ func (td *TestDaemon) Stop() *TestDaemon {
 
 // Restart restarts the daemon
 func (td *TestDaemon) Restart() *TestDaemon {
-	return td.Stop().Start()
+	td.Stop()
+	td.assertNoLogErrors()
+	return td.Start()
 }
 
 // Shutdown stops the daemon and deletes the repository.
@@ -411,6 +413,13 @@ func (td *TestDaemon) Shutdown() {
 func (td *TestDaemon) ShutdownSuccess() {
 	err := td.process.Process.Signal(syscall.SIGTERM)
 	assert.NoError(td.test, err)
+
+	td.assertNoLogErrors()
+
+	_ = os.RemoveAll(td.repoDir)
+}
+
+func (td *TestDaemon) assertNoLogErrors() {
 	tdErr := td.ReadStderr()
 
 	// We filter out errors expected from the cleanup associated with SIGTERM
@@ -428,8 +437,6 @@ func (td *TestDaemon) ShutdownSuccess() {
 
 	assert.NotContains(td.test, filteredStdErr, "CRITICAL")
 	assert.NotContains(td.test, filteredStdErr, "ERROR")
-
-	_ = os.RemoveAll(td.repoDir)
 }
 
 // ShutdownEasy stops the daemon using `SIGINT`.


### PR DESCRIPTION
progress towards #1879

### Problem

We think `MessageSendWithRetry` can get in a race when the first message succeeds but arrives in the block after the timeout. This a new message to be created that has a higher nonce and thus a different cid. When the original message receipt does arrive it doesn't match the cid, so it keeps going. It can stay in loop until the retry limit is reached this way.

### Solution

This PR does not fully address the problem. The solution probably involves waiting for any of the messages we have sent. In the mean time we increase the timeouts of code that uses message retry. We also improve the logging on message failures and have testDaemon.Restart() fail the test if an error occurs before the restart.