### PR TITLE
specifically check for groth parameter file in `copy_groth_params`

### DIFF
--- a/scripts/install-rust-proofs.sh
+++ b/scripts/install-rust-proofs.sh
@@ -54,6 +54,7 @@ install_precompiled() {
 }
 
 install_local() {
+  mkdir -p /tmp/filecoin-proof-parameters
   if ! [ -x "$(command -v cargo)" ] ; then
     echo 'Error: cargo is not installed.'
     echo 'Install Rust toolchain to resolve this problem.'


### PR DESCRIPTION
in function `copy_groth_params`this is a more specific and resilient check and has better readability