### PR TITLE
symlink groth params in final Docker image

### DIFF
--- a/Dockerfile.ci.filecoin
+++ b/Dockerfile.ci.filecoin
@@ -11,17 +11,16 @@ COPY --from=filecoin:all $SRC_DIR/gengen/gengen /usr/local/bin/gengen
 COPY --from=filecoin:all $SRC_DIR/fixtures/* /data/
 COPY --from=filecoin:all /tmp/su-exec/su-exec /sbin/su-exec
 COPY --from=filecoin:all /tmp/tini /sbin/tini
-COPY --from=filecoin:all /tmp/filecoin-proof-parameters/* /tmp/filecoin-proof-parameters/
+COPY --from=filecoin:all /tmp/filecoin-proof-parameters/v9-zigzag-* /tmp/filecoin-proof-parameters/
 COPY --from=filecoin:all /tmp/jq /usr/local/bin/jq
 COPY --from=filecoin:all /etc/ssl/certs /etc/ssl/certs
 
+RUN ln -s /tmp/filecoin-proof-parameters/v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8 /tmp/filecoin-proof-parameters/params.out
 # This shared lib (part of glibc) doesn't seem to be included with busybox.
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libdl-2.24.so /lib/libdl.so.2
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/librt.so.1 /lib/librt.so.1
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/libgcc_s.so.1
 COPY --from=filecoin:all /lib/x86_64-linux-gnu/libutil.so.1 /lib/libutil.so.1
-COPY --from=filecoin:all $SRC_DIR/proofs/rust-proofs/target/release/libfilecoin_proofs.so /lib/libfilecoin_proofs.so
-COPY --from=filecoin:all $SRC_DIR/proofs/rust-proofs/target/release/libsector_base.so /lib/libsector_base.so
 
 # Ports for Swarm and CmdAPI
 EXPOSE 6000


### PR DESCRIPTION
Avoid copying `params.out` symlink as it results in duplicating the contents of the `v9-zigzag..` file that it is symlinked to (due to docker behavior for `COPY`)
Create the symlink in a `RUN` step instead.
