### PR TITLE
[CircleCI] run apt-get update before aws cli install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,7 @@ jobs:
       - run:
           name: Install AWS CLI
           command: |
+            sudo apt-get update
             sudo apt-get install -y python-pip libyaml-dev python-dev jq
             sudo pip install awscli
       - run:


### PR DESCRIPTION
CircleCI docker_build_img job has been failing on apt-get install.
Example https://circleci.com/gh/filecoin-project/go-filecoin/16553

This fixes it. Here's a simplified test build based off this branch demonstration fix https://circleci.com/workflow-run/2395486d-e7d9-4bd8-97a4-39accb1fb5b7