### PR TITLE
Rewrite TestDealWithSameDataAndDifferentMiners as fast test with deterministic mining

### DIFF
--- a/commands/client_daemon_test.go
+++ b/commands/client_daemon_test.go
@@ -163,7 +163,7 @@ func TestDealWithSameDataAndDifferentMiners(t *testing.T) {
 
 	// create first miner
 	miner1Daemon := env.RequireNewNodeWithFunds(1111)
-	series.Connect(ctx, miner1Daemon, clientDaemon)
+	require.NoError(t, series.Connect(ctx, miner1Daemon, clientDaemon))
 	pparams, err := miner1Daemon.Protocol(ctx)
 	require.NoError(t, err)
 	sinfo := pparams.SupportedSectors[0]
@@ -171,17 +171,17 @@ func TestDealWithSameDataAndDifferentMiners(t *testing.T) {
 	// mine the create miner message, then mine the set ask message
 	series.CtxMiningNext(ctx, 2)
 	ask1, err := series.CreateStorageMinerWithAsk(ctx, miner1Daemon, collateral, price, expiry, sinfo.Size)
-	miner1Daemon.MiningSetup(ctx)
+	require.NoError(t, miner1Daemon.MiningSetup(ctx))
 	require.NoError(t, err)
 
 	// create second miner
 	miner2Daemon := env.RequireNewNodeWithFunds(1111)
-	series.Connect(ctx, miner2Daemon, clientDaemon)
+	require.NoError(t, series.Connect(ctx, miner2Daemon, clientDaemon))
 
 	// mine the create miner message, then mine the set ask message
 	series.CtxMiningNext(ctx, 2)
 	ask2, err := series.CreateStorageMinerWithAsk(ctx, miner2Daemon, collateral, price, expiry, sinfo.Size)
-	miner2Daemon.MiningSetup(ctx)
+	require.NoError(t, miner2Daemon.MiningSetup(ctx))
 	require.NoError(t, err)
 
 	// define data


### PR DESCRIPTION
fixes #3392

### Problem

`TestDealWithSameDataAndDifferentMiners` has been flaky. This test is written as an old style daemon test and was relying on calling `mining start` both to prepare the nodes to accept storage deals and to mine the messages needed to set up the miners and execute the deals. `mining start` causes the nodes to mine in a loop, and makes the timing of events extremely difficult to predict. Removing mining scheduling in favor of explicit mining using `CtxMiningOnce` and `CtxMiningNext` (only available in FAST tests) has significantly reduced (removed?) flakiness in integration tests.

### Solution

1. Rewrite this test as a FAST test. 
2. Use `mining.Setup` instead of `mining.Start` to prepare the mining nodes to receive storage deals.
3. Use `CtxMiningNext` to have the genesis node mine only when an expected message lands in the genesis node's mining queue.