### PR TITLE
WIP: Prove Deals Work To Completion In Integration Test

### DIFF
--- a/cmd/go-filecoin/client_integration_test.go
+++ b/cmd/go-filecoin/client_integration_test.go
@@ -61,16 +61,14 @@ func TestProposeDeal(t *testing.T) {
 
 	// wait for deal to process
 	var dealStatus storagemarket.ClientDeal
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 120; i++ {
 		clientAPI.RunMarshaledJSON(ctx, &dealStatus, "client", "query-storage-deal", result.ProposalCid.String())
 		switch dealStatus.State {
-		case storagemarket.StorageDealProposalAccepted,
-			storagemarket.StorageDealStaged,
-			storagemarket.StorageDealSealing,
-			storagemarket.StorageDealActive:
+		case storagemarket.StorageDealActive:
 			// Deal accepted. Test passed.
 			return
 		default:
+			t.Logf("Current deal state: %s", storagemarket.DealStates[dealStatus.State])
 			time.Sleep(1 * time.Second) // in progress, wait and continue
 		}
 	}


### PR DESCRIPTION
### Motivation

The issue in #4112 should have been caught in an integration test, but wasn't because the client propose-deal integration test only tested that a deal made it up to StorageDealProposalAccepted, which happens long before we verify actual sealing took place.

It's not clear what the right way to test this is -- sealing even of 2k sectors is not instantaneous.

### Proposed changes

modifies the integration test for deals to try to get to storage deal active, the actual complete
state for a deal

This is a brute force approach and I don't think it makes sense as a permaneant fix, but was simply the easiest way I could find to demonstrate the error. It probably merits some thought about the best approach, or maybe we just need to test sealing seperately.

Closes #
<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

