### PR TITLE
fix `syncerAPI.SyncSubmitBlock` causes `venus` panic in `offline` mode

### DIFF
--- a/app/node/node.go
+++ b/app/node/node.go
@@ -166,36 +166,34 @@ func (node *Node) Start(ctx context.Context) error {
 	var syncCtx context.Context
 	syncCtx, node.syncer.CancelChainSync = context.WithCancel(context.Background())
 
-	if !node.offlineMode {
-		// Start node discovery
-		err := node.discovery.Start()
-		if err != nil {
-			return err
-		}
-
-		//start syncer module to receive new blocks and start sync to latest height
-		err = node.syncer.Start(syncCtx)
-		if err != nil {
-			return err
-		}
-
-		//Start mpool module to receive new message
-		err = node.mpool.Start(syncCtx)
-		if err != nil {
-			return err
-		}
-
-		err = node.paychan.Start()
-		if err != nil {
-			return err
-		}
-
-		/*err = node.market.Start()
-		if err != nil {
-			return err
-		}*/
-
+	// Start node discovery
+	err := node.discovery.Start(node.offlineMode)
+	if err != nil {
+		return err
 	}
+
+	//start syncer module to receive new blocks and start sync to latest height
+	err = node.syncer.Start(syncCtx)
+	if err != nil {
+		return err
+	}
+
+	//Start mpool module to receive new message
+	err = node.mpool.Start(syncCtx)
+	if err != nil {
+		return err
+	}
+
+	err = node.paychan.Start()
+	if err != nil {
+		return err
+	}
+
+	/*err = node.market.Start()
+	if err != nil {
+		return err
+	}*/
+
 	return nil
 }
 

--- a/app/submodule/discovery/discovery_submodule.go
+++ b/app/submodule/discovery/discovery_submodule.go
@@ -94,7 +94,7 @@ func NewDiscoverySubmodule(ctx context.Context,
 
 // Start starts the discovery submodule for a node.  It blocks until bootstrap
 // satisfies the configured security conditions.
-func (discovery *DiscoverySubmodule) Start() error {
+func (discovery *DiscoverySubmodule) Start(offline bool) error {
 	// Register peer tracker disconnect function with network.
 	discovery.PeerTracker.RegisterDisconnect(discovery.host.Network())
 
@@ -108,14 +108,16 @@ func (discovery *DiscoverySubmodule) Start() error {
 	// Register the "hello" protocol with the network
 	discovery.HelloHandler.Register(peerDiscoveredCallback, discovery.TipSetLoader)
 
-	// Start bootstrapper.
-	discovery.Bootstrapper.Start(context.Background())
-
 	//registre exchange protocol
 	discovery.ExchangeHandler.Register()
 
-	// Wait for bootstrap to be sufficient connected
-	discovery.BootstrapReady.Wait()
+	// Start bootstrapper.
+	if !offline {
+		discovery.Bootstrapper.Start(context.Background())
+		// Wait for bootstrap to be sufficient connected
+		discovery.BootstrapReady.Wait()
+	}
+
 	return nil
 }
 

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -71,19 +71,22 @@ func (b *Bootstrapper) Start(ctx context.Context) {
 	b.ctx, b.cancel = context.WithCancel(ctx)
 	b.ticker = time.NewTicker(b.Period)
 
-	b.Bootstrap(nil) //boot first
-	go func() {
-		defer b.ticker.Stop()
+	b.Bootstrap(nil) // boot first
 
-		for {
-			select {
-			case <-b.ctx.Done():
-				return
-			case <-b.ticker.C:
-				b.Bootstrap(b.d.Peers())
-			}
-		}
-	}()
+	// following commented logical was replaced by `PeerManager`
+
+	// go func() {
+	// 	defer b.ticker.Stop()
+	//
+	// 	for {
+	// 		select {
+	// 		case <-b.ctx.Done():
+	// 			return
+	// 		case <-b.ticker.C:
+	// 			b.Bootstrap(b.d.Peers())
+	// 		}
+	// 	}
+	// }()
 }
 
 // Stop stops the Bootstrapper.

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -41,7 +41,8 @@ type Bootstrapper struct {
 	Bootstrap func([]peer.ID)
 
 	// Bookkeeping
-	ticker        *time.Ticker
+	/* never use `ticker` again */
+	// ticker        *time.Ticker
 	ctx           context.Context
 	cancel        context.CancelFunc
 	filecoinPeers *moresync.Latch
@@ -69,12 +70,12 @@ func NewBootstrapper(bootstrapPeers []peer.AddrInfo, h host.Host, d inet.Dialer,
 // Start starts the Bootstrapper bootstrapping. Cancel `ctx` or call Stop() to stop it.
 func (b *Bootstrapper) Start(ctx context.Context) {
 	b.ctx, b.cancel = context.WithCancel(ctx)
-	b.ticker = time.NewTicker(b.Period)
-
 	b.Bootstrap(nil) // boot first
 
-	// following commented logical was replaced by `PeerManager`
+	// does't need a ticker anymore
+	// b.ticker = time.NewTicker(b.Period)
 
+	/* following commented logical was replaced by `PeerManager` */
 	// go func() {
 	// 	defer b.ticker.Stop()
 	//

--- a/pkg/discovery/bootstrap_test.go
+++ b/pkg/discovery/bootstrap_test.go
@@ -46,7 +46,7 @@ func TestBootstrapperStartAndStop(t *testing.T) {
 		lk.Lock()
 		defer lk.Unlock()
 		callCount++
-		if callCount == 3 {
+		if callCount == 1 {
 
 			// If b.Period is configured to be a too small, b.ticker will tick
 			// again before the context's done-channel sees a value. This
@@ -60,7 +60,7 @@ func TestBootstrapperStartAndStop(t *testing.T) {
 
 	lk.Lock()
 	defer lk.Unlock()
-	assert.Equal(t, 3, callCount)
+	assert.Equal(t, 1, callCount)
 }
 
 func TestBootstrapperBootstrap(t *testing.T) {


### PR DESCRIPTION
fix `syncerAPI.SyncSubmitBlock` panic in `offline` mode
and make it have the same behavior as running `lotus daemon` with the flag `bootstrap=true`

- [x] test cli command: `venus swarm connect address`
- [x] test syncerAPI.SyncSubmitBlock api in a private network
- [x] make sure `venus`(start with `offline=true`) sync blocks correctly  after execute  command: `venus swarm connect ...`.
- [x] make sure a miner(connect a `venus` node start with `offline=ture`) mine  blocks correctly