### PR TITLE
switch from IPFS_REUSEPORT to LIBP2P_TCP_REUSEPORT

### DIFF
--- a/pkg/testhelpers/test_daemon.go
+++ b/pkg/testhelpers/test_daemon.go
@@ -750,7 +750,7 @@ func (td *TestDaemon) createNewProcess() {
 
 	td.process = exec.Command(td.daemonArgs[0], td.daemonArgs[1:]...)
 	// disable REUSEPORT, it creates problems in tests
-	td.process.Env = append(os.Environ(), "IPFS_REUSEPORT=false")
+	td.process.Env = append(os.Environ(), "LIBP2P_TCP_REUSEPORT=false")
 
 	// setup process pipes
 	var err error


### PR DESCRIPTION
### Motivation

The IPFS_REUSEPORT environment variable has been deprecated for LIBP2P_TCP_REUSEPORT since 2018 and has finally been dropped in the latest go-tcp-transport https://github.com/libp2p/go-tcp-transport/pull/104.

### Proposed changes

Switch the environment variable

Closes #

<!-- Add the label "protocol breaking" if this PR alters protocol compatibility -->

