### PR TITLE
fix:un-consensus api StateMinerPreCommitDepositForPower

### DIFF
--- a/app/submodule/chain/miner_api.go
+++ b/app/submodule/chain/miner_api.go
@@ -342,7 +342,7 @@ func (msa *minerStateAPI) StateMinerPreCommitDepositForPower(ctx context.Context
 	}
 
 	var sTree *tree.State
-	ts, sTree, err = msa.Stmgr.ParentState(ctx, ts)
+	_, sTree, err = msa.Stmgr.ParentState(ctx, ts)
 	if err != nil {
 		return big.Int{}, xerrors.Errorf("ParentState failed:%v", err)
 	}


### PR DESCRIPTION
fix api result un-consensus with lotus:
- method:`StateMinerPreCommitDepositForPower`
- params:
`['f01578658', {'SealProof': 8, 'SectorNumber': 17661, 'SealedCID': {'/': 'bagboea4b5abcbejuhtmxfu4onwodjoexmm2nklwdbgh4kd55vatxfgbundz2ddia'}, 'SealRandEpoch': 1437643, 'DealIDs': [3218825], 'Expiration': 2992929, 'ReplaceCapacity': False, 'ReplaceSectorDeadline': 0, 'ReplaceSectorPartition': 0, 'ReplaceSectorNumber': 0}, [{'/': 'bafy2bzacea2bq6apooij7pqoxuef43vwcy4ins5m3homyq7fgons3g223yi6e'}, {'/': 'bafy2bzacea7pncy27vyk55lujkbukoro2ls22xvhblbbo4gc4uvikp42xdbsc'}]]`
- response :
`from lotus : 145614631696114499
from venus : 145614547699876820`