### PR TITLE
fix json marshal/unmarshal for FIL type

### DIFF
--- a/pkg/types/internal/fil.go
+++ b/pkg/types/internal/fil.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding"
+	"encoding/json"
 	"fmt"
 	fbig "github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/venus/pkg/constants"
@@ -85,6 +86,24 @@ func (f FIL) UnmarshalText(text []byte) error {
 	return nil
 }
 
+func (f FIL) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + f.String() + "\""), nil
+}
+
+func (f *FIL) UnmarshalJSON(by []byte) error {
+	p, err := ParseFIL(strings.Trim(string(by), "\""))
+	if err != nil {
+		return err
+	}
+	if f.Int != nil {
+		f.Int.Set(p.Int)
+	} else {
+		f.Int = p.Int
+	}
+
+	return nil
+}
+
 func ParseFIL(s string) (FIL, error) {
 	suffix := strings.TrimLeft(s, "-.1234567890")
 	s = s[:len(s)-len(suffix)]
@@ -135,3 +154,6 @@ func MustParseFIL(s string) FIL {
 
 var _ encoding.TextMarshaler = (*FIL)(nil)
 var _ encoding.TextUnmarshaler = (*FIL)(nil)
+
+var _ json.Marshaler = (*FIL)(nil)
+var _ json.Unmarshaler = (*FIL)(nil)

--- a/pkg/types/internal/fil_test.go
+++ b/pkg/types/internal/fil_test.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"encoding/json"
+	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,5 +113,49 @@ func TestFilShort(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, s.expect, f.Short())
 		})
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	type A struct {
+		Fil FIL
+	}
+	var a = A{
+		Fil: FIL{big.NewInt(1000000)},
+	}
+
+	aBytes, err := json.Marshal(a)
+	require.NoError(t, err)
+
+	require.Equal(t, aBytes, []byte("{\"Fil\":\"0.000000000001 FIL\"}"))
+	fmt.Println(string(aBytes))
+}
+
+func TestUnMarshal(t *testing.T) {
+	type A struct {
+		Fil FIL
+	}
+	bigFIl, _ := big.NewInt(0).SetString("100000000000000000000", 10)
+	for _, s := range []struct {
+		fil    string
+		expect FIL
+	}{
+		{
+			fil:    "{\"Fil\":\"0.000000000001 FIL\"}",
+			expect: FIL{big.NewInt(1000000)},
+		},
+		{
+			fil:    "{\"Fil\":\"1 FIL\"}",
+			expect: FIL{big.NewInt(1000000000000000000)},
+		},
+		{
+			fil:    "{\"Fil\":\"100 FIL\"}",
+			expect: FIL{bigFIl},
+		},
+	} {
+		a := A{}
+		err := json.Unmarshal([]byte(s.fil), &a)
+		require.NoError(t, err)
+		require.Equal(t, a.Fil.String(), s.expect.String())
 	}
 }


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes

support json marshal and unmarshal for type FIl.  maxfee become more clear in config.json

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
    - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_, _perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _venus_, _venus-messager_, _venus-miner_, _venus-gateway_, _venus-auth_, _venus-market_, _venus-sealer_, _venus-wallet_, _venus-cluster_, _api_, _chain_, _state_, _vm_, _data transfer_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in [venus docs](https://venus.filecoin.io) or [Discussion Tutorials.](https://github.com/filecoin-project/venus/discussions/categories/tutorials)
- [ ] CI is green