### PR TITLE
fix: venus-shared: deal proposal usage

### DIFF
--- a/venus-shared/types/market/assigner_type.go
+++ b/venus-shared/types/market/assigner_type.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-state-types/abi"
+	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 
 	"github.com/filecoin-project/venus/venus-shared/actors/builtin/market"
 )
@@ -38,7 +39,7 @@ type DealInfoIncludePath struct {
 	PayloadSize     abi.UnpaddedPieceSize
 	DealID          abi.DealID
 	TotalStorageFee abi.TokenAmount
-	market.DealProposal
+	market7.DealProposal
 	FastRetrieval bool
 	PublishCid    cid.Cid
 }

--- a/venus-shared/types/market/storage.go
+++ b/venus-shared/types/market/storage.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	market7 "github.com/filecoin-project/specs-actors/v7/actors/builtin/market"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/venus/venus-shared/actors/builtin/market"
@@ -28,7 +29,7 @@ type SectorOffset struct {
 type PieceDealInfo struct {
 	PublishCid   *cid.Cid
 	DealID       abi.DealID
-	DealProposal *market.DealProposal
+	DealProposal *market7.DealProposal
 	DealSchedule DealSchedule
 	KeepUnsealed bool
 }


### PR DESCRIPTION
## Related Issues
no

## Proposed Changes
- use `DealProposal` insde `specs-actors`, instead of `venus-shared/actors/builtin/market`


## Additional Info
no

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
    - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_, _perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _venus_, _venus-messager_, _venus-miner_, _venus-gateway_, _venus-auth_, _venus-market_, _venus-sealer_, _venus-wallet_, _venus-cluster_, _api_, _chain_, _state_, _vm_, _data transfer_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] CI is green