### PR TITLE
refactor: venus-share: split-gateway-interfaces-by-role

### DIFF
--- a/venus-shared/api/gateway/v0/market_event.go
+++ b/venus-shared/api/gateway/v0/market_event.go
@@ -12,10 +12,17 @@ import (
 )
 
 type IMarketEvent interface {
+	IMarketClient
+	IMarketServiceProvider
+}
+
+type IMarketClient interface {
 	ListMarketConnectionsState(ctx context.Context) ([]gtypes.MarketConnectionState, error)                                                                                               //perm:admin
 	IsUnsealed(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize) (bool, error)              //perm:admin
 	SectorsUnsealPiece(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize, dest string) error //perm:admin
+}
 
+type IMarketServiceProvider interface {
 	ResponseMarketEvent(ctx context.Context, resp *gtypes.ResponseEvent) error                                       //perm:read
 	ListenMarketEvent(ctx context.Context, policy *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) //perm:read
 }

--- a/venus-shared/api/gateway/v0/method.md
+++ b/venus-shared/api/gateway/v0/method.md
@@ -1,29 +1,32 @@
 # Groups
 
-* [MarketEvent](#MarketEvent)
+* [MarketClient](#MarketClient)
   * [IsUnsealed](#IsUnsealed)
   * [ListMarketConnectionsState](#ListMarketConnectionsState)
+  * [SectorsUnsealPiece](#SectorsUnsealPiece)
+* [MarketServiceProvider](#MarketServiceProvider)
   * [ListenMarketEvent](#ListenMarketEvent)
   * [ResponseMarketEvent](#ResponseMarketEvent)
-  * [SectorsUnsealPiece](#SectorsUnsealPiece)
-* [ProofEvent](#ProofEvent)
+* [ProofClient](#ProofClient)
   * [ComputeProof](#ComputeProof)
   * [ListConnectedMiners](#ListConnectedMiners)
   * [ListMinerConnection](#ListMinerConnection)
+* [ProofServiceProvider](#ProofServiceProvider)
   * [ListenProofEvent](#ListenProofEvent)
   * [ResponseProofEvent](#ResponseProofEvent)
-* [WalletEvent](#WalletEvent)
-  * [AddNewAddress](#AddNewAddress)
+* [WalletClient](#WalletClient)
   * [ListWalletInfo](#ListWalletInfo)
   * [ListWalletInfoByWallet](#ListWalletInfoByWallet)
+  * [WalletHas](#WalletHas)
+  * [WalletSign](#WalletSign)
+* [WalletServiceProvider](#WalletServiceProvider)
+  * [AddNewAddress](#AddNewAddress)
   * [ListenWalletEvent](#ListenWalletEvent)
   * [RemoveAddress](#RemoveAddress)
   * [ResponseWalletEvent](#ResponseWalletEvent)
   * [SupportNewAccount](#SupportNewAccount)
-  * [WalletHas](#WalletHas)
-  * [WalletSign](#WalletSign)
 
-## MarketEvent
+## MarketClient
 
 ### IsUnsealed
 
@@ -81,6 +84,35 @@ Response:
 ]
 ```
 
+### SectorsUnsealPiece
+
+
+Perms: admin
+
+Inputs:
+```json
+[
+  "f01234",
+  {
+    "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+  },
+  {
+    "ID": {
+      "Miner": 1000,
+      "Number": 9
+    },
+    "ProofType": 8
+  },
+  10,
+  1032,
+  "string value"
+]
+```
+
+Response: `{}`
+
+## MarketServiceProvider
+
 ### ListenMarketEvent
 
 
@@ -122,34 +154,7 @@ Inputs:
 
 Response: `{}`
 
-### SectorsUnsealPiece
-
-
-Perms: admin
-
-Inputs:
-```json
-[
-  "f01234",
-  {
-    "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
-  },
-  {
-    "ID": {
-      "Miner": 1000,
-      "Number": 9
-    },
-    "ProofType": 8
-  },
-  10,
-  1032,
-  "string value"
-]
-```
-
-Response: `{}`
-
-## ProofEvent
+## ProofClient
 
 ### ComputeProof
 
@@ -227,6 +232,8 @@ Response:
 }
 ```
 
+## ProofServiceProvider
+
 ### ListenProofEvent
 
 
@@ -268,24 +275,7 @@ Inputs:
 
 Response: `{}`
 
-## WalletEvent
-
-### AddNewAddress
-
-
-Perms: read
-
-Inputs:
-```json
-[
-  "e26f1e5c-47f7-4561-a11d-18fab6e748af",
-  [
-    "f01234"
-  ]
-]
-```
-
-Response: `{}`
+## WalletClient
 
 ### ListWalletInfo
 
@@ -349,6 +339,66 @@ Response:
   ]
 }
 ```
+
+### WalletHas
+
+
+Perms: admin
+
+Inputs:
+```json
+[
+  "string value",
+  "f01234"
+]
+```
+
+Response: `true`
+
+### WalletSign
+
+
+Perms: admin
+
+Inputs:
+```json
+[
+  "string value",
+  "f01234",
+  "Ynl0ZSBhcnJheQ==",
+  {
+    "Type": "message",
+    "Extra": "Ynl0ZSBhcnJheQ=="
+  }
+]
+```
+
+Response:
+```json
+{
+  "Type": 2,
+  "Data": "Ynl0ZSBhcnJheQ=="
+}
+```
+
+## WalletServiceProvider
+
+### AddNewAddress
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  "e26f1e5c-47f7-4561-a11d-18fab6e748af",
+  [
+    "f01234"
+  ]
+]
+```
+
+Response: `{}`
 
 ### ListenWalletEvent
 
@@ -425,45 +475,4 @@ Inputs:
 ```
 
 Response: `{}`
-
-### WalletHas
-
-
-Perms: admin
-
-Inputs:
-```json
-[
-  "string value",
-  "f01234"
-]
-```
-
-Response: `true`
-
-### WalletSign
-
-
-Perms: admin
-
-Inputs:
-```json
-[
-  "string value",
-  "f01234",
-  "Ynl0ZSBhcnJheQ==",
-  {
-    "Type": "message",
-    "Extra": "Ynl0ZSBhcnJheQ=="
-  }
-]
-```
-
-Response:
-```json
-{
-  "Type": 2,
-  "Data": "Ynl0ZSBhcnJheQ=="
-}
-```
 

--- a/venus-shared/api/gateway/v0/proof_event.go
+++ b/venus-shared/api/gateway/v0/proof_event.go
@@ -10,10 +10,17 @@ import (
 )
 
 type IProofEvent interface {
+	IProofClient
+	IProofServiceProvider
+}
+
+type IProofClient interface {
 	ListConnectedMiners(ctx context.Context) ([]address.Address, error)                                                                              //perm:admin
 	ListMinerConnection(ctx context.Context, addr address.Address) (*gtypes.MinerState, error)                                                       //perm:admin
 	ComputeProof(ctx context.Context, miner address.Address, sectorInfos []builtin.SectorInfo, rand abi.PoStRandomness) ([]builtin.PoStProof, error) //perm:admin
+}
 
+type IProofServiceProvider interface {
 	ResponseProofEvent(ctx context.Context, resp *gtypes.ResponseEvent) error                                      //perm:read
 	ListenProofEvent(ctx context.Context, policy *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) //perm:read
 }

--- a/venus-shared/api/gateway/v0/proxy_gen.go
+++ b/venus-shared/api/gateway/v0/proxy_gen.go
@@ -15,98 +15,131 @@ import (
 	gtypes "github.com/filecoin-project/venus/venus-shared/types/gateway"
 )
 
-type IProofEventStruct struct {
+type IProofClientStruct struct {
 	Internal struct {
 		ComputeProof        func(ctx context.Context, miner address.Address, sectorInfos []builtin.SectorInfo, rand abi.PoStRandomness) ([]builtin.PoStProof, error) `perm:"admin"`
 		ListConnectedMiners func(ctx context.Context) ([]address.Address, error)                                                                                     `perm:"admin"`
 		ListMinerConnection func(ctx context.Context, addr address.Address) (*gtypes.MinerState, error)                                                              `perm:"admin"`
-		ListenProofEvent    func(ctx context.Context, policy *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error)                                       `perm:"read"`
-		ResponseProofEvent  func(ctx context.Context, resp *gtypes.ResponseEvent) error                                                                              `perm:"read"`
 	}
 }
 
-func (s *IProofEventStruct) ComputeProof(p0 context.Context, p1 address.Address, p2 []builtin.SectorInfo, p3 abi.PoStRandomness) ([]builtin.PoStProof, error) {
+func (s *IProofClientStruct) ComputeProof(p0 context.Context, p1 address.Address, p2 []builtin.SectorInfo, p3 abi.PoStRandomness) ([]builtin.PoStProof, error) {
 	return s.Internal.ComputeProof(p0, p1, p2, p3)
 }
-func (s *IProofEventStruct) ListConnectedMiners(p0 context.Context) ([]address.Address, error) {
+func (s *IProofClientStruct) ListConnectedMiners(p0 context.Context) ([]address.Address, error) {
 	return s.Internal.ListConnectedMiners(p0)
 }
-func (s *IProofEventStruct) ListMinerConnection(p0 context.Context, p1 address.Address) (*gtypes.MinerState, error) {
+func (s *IProofClientStruct) ListMinerConnection(p0 context.Context, p1 address.Address) (*gtypes.MinerState, error) {
 	return s.Internal.ListMinerConnection(p0, p1)
 }
-func (s *IProofEventStruct) ListenProofEvent(p0 context.Context, p1 *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
+
+type IProofServiceProviderStruct struct {
+	Internal struct {
+		ListenProofEvent   func(ctx context.Context, policy *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) `perm:"read"`
+		ResponseProofEvent func(ctx context.Context, resp *gtypes.ResponseEvent) error                                        `perm:"read"`
+	}
+}
+
+func (s *IProofServiceProviderStruct) ListenProofEvent(p0 context.Context, p1 *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
 	return s.Internal.ListenProofEvent(p0, p1)
 }
-func (s *IProofEventStruct) ResponseProofEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
+func (s *IProofServiceProviderStruct) ResponseProofEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
 	return s.Internal.ResponseProofEvent(p0, p1)
 }
 
-type IWalletEventStruct struct {
+type IProofEventStruct struct {
+	IProofClientStruct
+	IProofServiceProviderStruct
+}
+
+type IWalletClientStruct struct {
 	Internal struct {
-		AddNewAddress          func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                                             `perm:"read"`
 		ListWalletInfo         func(ctx context.Context) ([]*gtypes.WalletDetail, error)                                                                     `perm:"admin"`
 		ListWalletInfoByWallet func(ctx context.Context, wallet string) (*gtypes.WalletDetail, error)                                                        `perm:"admin"`
-		ListenWalletEvent      func(ctx context.Context, policy *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error)                           `perm:"read"`
-		RemoveAddress          func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                                             `perm:"read"`
-		ResponseWalletEvent    func(ctx context.Context, resp *gtypes.ResponseEvent) error                                                                   `perm:"read"`
-		SupportNewAccount      func(ctx context.Context, channelID types.UUID, account string) error                                                         `perm:"read"`
 		WalletHas              func(ctx context.Context, supportAccount string, addr address.Address) (bool, error)                                          `perm:"admin"`
 		WalletSign             func(ctx context.Context, account string, addr address.Address, toSign []byte, meta types.MsgMeta) (*crypto.Signature, error) `perm:"admin"`
 	}
 }
 
-func (s *IWalletEventStruct) AddNewAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
-	return s.Internal.AddNewAddress(p0, p1, p2)
-}
-func (s *IWalletEventStruct) ListWalletInfo(p0 context.Context) ([]*gtypes.WalletDetail, error) {
+func (s *IWalletClientStruct) ListWalletInfo(p0 context.Context) ([]*gtypes.WalletDetail, error) {
 	return s.Internal.ListWalletInfo(p0)
 }
-func (s *IWalletEventStruct) ListWalletInfoByWallet(p0 context.Context, p1 string) (*gtypes.WalletDetail, error) {
+func (s *IWalletClientStruct) ListWalletInfoByWallet(p0 context.Context, p1 string) (*gtypes.WalletDetail, error) {
 	return s.Internal.ListWalletInfoByWallet(p0, p1)
 }
-func (s *IWalletEventStruct) ListenWalletEvent(p0 context.Context, p1 *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
-	return s.Internal.ListenWalletEvent(p0, p1)
-}
-func (s *IWalletEventStruct) RemoveAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
-	return s.Internal.RemoveAddress(p0, p1, p2)
-}
-func (s *IWalletEventStruct) ResponseWalletEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
-	return s.Internal.ResponseWalletEvent(p0, p1)
-}
-func (s *IWalletEventStruct) SupportNewAccount(p0 context.Context, p1 types.UUID, p2 string) error {
-	return s.Internal.SupportNewAccount(p0, p1, p2)
-}
-func (s *IWalletEventStruct) WalletHas(p0 context.Context, p1 string, p2 address.Address) (bool, error) {
+func (s *IWalletClientStruct) WalletHas(p0 context.Context, p1 string, p2 address.Address) (bool, error) {
 	return s.Internal.WalletHas(p0, p1, p2)
 }
-func (s *IWalletEventStruct) WalletSign(p0 context.Context, p1 string, p2 address.Address, p3 []byte, p4 types.MsgMeta) (*crypto.Signature, error) {
+func (s *IWalletClientStruct) WalletSign(p0 context.Context, p1 string, p2 address.Address, p3 []byte, p4 types.MsgMeta) (*crypto.Signature, error) {
 	return s.Internal.WalletSign(p0, p1, p2, p3, p4)
 }
 
-type IMarketEventStruct struct {
+type IWalletServiceProviderStruct struct {
+	Internal struct {
+		AddNewAddress       func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                   `perm:"read"`
+		ListenWalletEvent   func(ctx context.Context, policy *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) `perm:"read"`
+		RemoveAddress       func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                   `perm:"read"`
+		ResponseWalletEvent func(ctx context.Context, resp *gtypes.ResponseEvent) error                                         `perm:"read"`
+		SupportNewAccount   func(ctx context.Context, channelID types.UUID, account string) error                               `perm:"read"`
+	}
+}
+
+func (s *IWalletServiceProviderStruct) AddNewAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
+	return s.Internal.AddNewAddress(p0, p1, p2)
+}
+func (s *IWalletServiceProviderStruct) ListenWalletEvent(p0 context.Context, p1 *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
+	return s.Internal.ListenWalletEvent(p0, p1)
+}
+func (s *IWalletServiceProviderStruct) RemoveAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
+	return s.Internal.RemoveAddress(p0, p1, p2)
+}
+func (s *IWalletServiceProviderStruct) ResponseWalletEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
+	return s.Internal.ResponseWalletEvent(p0, p1)
+}
+func (s *IWalletServiceProviderStruct) SupportNewAccount(p0 context.Context, p1 types.UUID, p2 string) error {
+	return s.Internal.SupportNewAccount(p0, p1, p2)
+}
+
+type IWalletEventStruct struct {
+	IWalletClientStruct
+	IWalletServiceProviderStruct
+}
+
+type IMarketClientStruct struct {
 	Internal struct {
 		IsUnsealed                 func(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize) (bool, error)      `perm:"admin"`
 		ListMarketConnectionsState func(ctx context.Context) ([]gtypes.MarketConnectionState, error)                                                                                                       `perm:"admin"`
-		ListenMarketEvent          func(ctx context.Context, policy *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error)                                                                     `perm:"read"`
-		ResponseMarketEvent        func(ctx context.Context, resp *gtypes.ResponseEvent) error                                                                                                             `perm:"read"`
 		SectorsUnsealPiece         func(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize, dest string) error `perm:"admin"`
 	}
 }
 
-func (s *IMarketEventStruct) IsUnsealed(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize) (bool, error) {
+func (s *IMarketClientStruct) IsUnsealed(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize) (bool, error) {
 	return s.Internal.IsUnsealed(p0, p1, p2, p3, p4, p5)
 }
-func (s *IMarketEventStruct) ListMarketConnectionsState(p0 context.Context) ([]gtypes.MarketConnectionState, error) {
+func (s *IMarketClientStruct) ListMarketConnectionsState(p0 context.Context) ([]gtypes.MarketConnectionState, error) {
 	return s.Internal.ListMarketConnectionsState(p0)
 }
-func (s *IMarketEventStruct) ListenMarketEvent(p0 context.Context, p1 *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
+func (s *IMarketClientStruct) SectorsUnsealPiece(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize, p6 string) error {
+	return s.Internal.SectorsUnsealPiece(p0, p1, p2, p3, p4, p5, p6)
+}
+
+type IMarketServiceProviderStruct struct {
+	Internal struct {
+		ListenMarketEvent   func(ctx context.Context, policy *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) `perm:"read"`
+		ResponseMarketEvent func(ctx context.Context, resp *gtypes.ResponseEvent) error                                         `perm:"read"`
+	}
+}
+
+func (s *IMarketServiceProviderStruct) ListenMarketEvent(p0 context.Context, p1 *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
 	return s.Internal.ListenMarketEvent(p0, p1)
 }
-func (s *IMarketEventStruct) ResponseMarketEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
+func (s *IMarketServiceProviderStruct) ResponseMarketEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
 	return s.Internal.ResponseMarketEvent(p0, p1)
 }
-func (s *IMarketEventStruct) SectorsUnsealPiece(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize, p6 string) error {
-	return s.Internal.SectorsUnsealPiece(p0, p1, p2, p3, p4, p5, p6)
+
+type IMarketEventStruct struct {
+	IMarketClientStruct
+	IMarketServiceProviderStruct
 }
 
 type IGatewayStruct struct {

--- a/venus-shared/api/gateway/v0/wallet_event.go
+++ b/venus-shared/api/gateway/v0/wallet_event.go
@@ -11,11 +11,19 @@ import (
 )
 
 type IWalletEvent interface {
+	IWalletClient
+	IWalletServiceProvider
+}
+
+type IWalletClient interface {
 	ListWalletInfo(ctx context.Context) ([]*gtypes.WalletDetail, error)                                                                 //perm:admin
 	ListWalletInfoByWallet(ctx context.Context, wallet string) (*gtypes.WalletDetail, error)                                            //perm:admin
 	WalletHas(ctx context.Context, supportAccount string, addr address.Address) (bool, error)                                           //perm:admin
 	WalletSign(ctx context.Context, account string, addr address.Address, toSign []byte, meta types.MsgMeta) (*crypto.Signature, error) //perm:admin
 
+}
+
+type IWalletServiceProvider interface {
 	ResponseWalletEvent(ctx context.Context, resp *gtypes.ResponseEvent) error                                       //perm:read
 	ListenWalletEvent(ctx context.Context, policy *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) //perm:read
 	SupportNewAccount(ctx context.Context, channelID types.UUID, account string) error                               //perm:read

--- a/venus-shared/api/gateway/v1/market_event.go
+++ b/venus-shared/api/gateway/v1/market_event.go
@@ -12,10 +12,17 @@ import (
 )
 
 type IMarketEvent interface {
+	IMarketClient
+	IMarketServiceProvider
+}
+
+type IMarketClient interface {
 	ListMarketConnectionsState(ctx context.Context) ([]gtypes.MarketConnectionState, error)                                                                                               //perm:admin
 	IsUnsealed(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize) (bool, error)              //perm:admin
 	SectorsUnsealPiece(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize, dest string) error //perm:admin
+}
 
+type IMarketServiceProvider interface {
 	ResponseMarketEvent(ctx context.Context, resp *gtypes.ResponseEvent) error                                       //perm:read
 	ListenMarketEvent(ctx context.Context, policy *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) //perm:read
 }

--- a/venus-shared/api/gateway/v1/method.md
+++ b/venus-shared/api/gateway/v1/method.md
@@ -1,29 +1,32 @@
 # Groups
 
-* [MarketEvent](#MarketEvent)
+* [MarketClient](#MarketClient)
   * [IsUnsealed](#IsUnsealed)
   * [ListMarketConnectionsState](#ListMarketConnectionsState)
+  * [SectorsUnsealPiece](#SectorsUnsealPiece)
+* [MarketServiceProvider](#MarketServiceProvider)
   * [ListenMarketEvent](#ListenMarketEvent)
   * [ResponseMarketEvent](#ResponseMarketEvent)
-  * [SectorsUnsealPiece](#SectorsUnsealPiece)
-* [ProofEvent](#ProofEvent)
+* [ProofClient](#ProofClient)
   * [ComputeProof](#ComputeProof)
   * [ListConnectedMiners](#ListConnectedMiners)
   * [ListMinerConnection](#ListMinerConnection)
+* [ProofServiceProvider](#ProofServiceProvider)
   * [ListenProofEvent](#ListenProofEvent)
   * [ResponseProofEvent](#ResponseProofEvent)
-* [WalletEvent](#WalletEvent)
-  * [AddNewAddress](#AddNewAddress)
+* [WalletClient](#WalletClient)
   * [ListWalletInfo](#ListWalletInfo)
   * [ListWalletInfoByWallet](#ListWalletInfoByWallet)
+  * [WalletHas](#WalletHas)
+  * [WalletSign](#WalletSign)
+* [WalletServiceProvider](#WalletServiceProvider)
+  * [AddNewAddress](#AddNewAddress)
   * [ListenWalletEvent](#ListenWalletEvent)
   * [RemoveAddress](#RemoveAddress)
   * [ResponseWalletEvent](#ResponseWalletEvent)
   * [SupportNewAccount](#SupportNewAccount)
-  * [WalletHas](#WalletHas)
-  * [WalletSign](#WalletSign)
 
-## MarketEvent
+## MarketClient
 
 ### IsUnsealed
 
@@ -81,6 +84,35 @@ Response:
 ]
 ```
 
+### SectorsUnsealPiece
+
+
+Perms: admin
+
+Inputs:
+```json
+[
+  "f01234",
+  {
+    "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
+  },
+  {
+    "ID": {
+      "Miner": 1000,
+      "Number": 9
+    },
+    "ProofType": 8
+  },
+  10,
+  1032,
+  "string value"
+]
+```
+
+Response: `{}`
+
+## MarketServiceProvider
+
 ### ListenMarketEvent
 
 
@@ -122,34 +154,7 @@ Inputs:
 
 Response: `{}`
 
-### SectorsUnsealPiece
-
-
-Perms: admin
-
-Inputs:
-```json
-[
-  "f01234",
-  {
-    "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
-  },
-  {
-    "ID": {
-      "Miner": 1000,
-      "Number": 9
-    },
-    "ProofType": 8
-  },
-  10,
-  1032,
-  "string value"
-]
-```
-
-Response: `{}`
-
-## ProofEvent
+## ProofClient
 
 ### ComputeProof
 
@@ -230,6 +235,8 @@ Response:
 }
 ```
 
+## ProofServiceProvider
+
 ### ListenProofEvent
 
 
@@ -271,24 +278,7 @@ Inputs:
 
 Response: `{}`
 
-## WalletEvent
-
-### AddNewAddress
-
-
-Perms: read
-
-Inputs:
-```json
-[
-  "e26f1e5c-47f7-4561-a11d-18fab6e748af",
-  [
-    "f01234"
-  ]
-]
-```
-
-Response: `{}`
+## WalletClient
 
 ### ListWalletInfo
 
@@ -352,6 +342,66 @@ Response:
   ]
 }
 ```
+
+### WalletHas
+
+
+Perms: admin
+
+Inputs:
+```json
+[
+  "string value",
+  "f01234"
+]
+```
+
+Response: `true`
+
+### WalletSign
+
+
+Perms: admin
+
+Inputs:
+```json
+[
+  "string value",
+  "f01234",
+  "Ynl0ZSBhcnJheQ==",
+  {
+    "Type": "message",
+    "Extra": "Ynl0ZSBhcnJheQ=="
+  }
+]
+```
+
+Response:
+```json
+{
+  "Type": 2,
+  "Data": "Ynl0ZSBhcnJheQ=="
+}
+```
+
+## WalletServiceProvider
+
+### AddNewAddress
+
+
+Perms: read
+
+Inputs:
+```json
+[
+  "e26f1e5c-47f7-4561-a11d-18fab6e748af",
+  [
+    "f01234"
+  ]
+]
+```
+
+Response: `{}`
 
 ### ListenWalletEvent
 
@@ -428,45 +478,4 @@ Inputs:
 ```
 
 Response: `{}`
-
-### WalletHas
-
-
-Perms: admin
-
-Inputs:
-```json
-[
-  "string value",
-  "f01234"
-]
-```
-
-Response: `true`
-
-### WalletSign
-
-
-Perms: admin
-
-Inputs:
-```json
-[
-  "string value",
-  "f01234",
-  "Ynl0ZSBhcnJheQ==",
-  {
-    "Type": "message",
-    "Extra": "Ynl0ZSBhcnJheQ=="
-  }
-]
-```
-
-Response:
-```json
-{
-  "Type": 2,
-  "Data": "Ynl0ZSBhcnJheQ=="
-}
-```
 

--- a/venus-shared/api/gateway/v1/proof_event.go
+++ b/venus-shared/api/gateway/v1/proof_event.go
@@ -12,10 +12,17 @@ import (
 )
 
 type IProofEvent interface {
+	IProofClient
+	IProofServiceProvider
+}
+
+type IProofClient interface {
 	ListConnectedMiners(ctx context.Context) ([]address.Address, error)                                                                                                                                        //perm:admin
 	ListMinerConnection(ctx context.Context, addr address.Address) (*gtypes.MinerState, error)                                                                                                                 //perm:admin
 	ComputeProof(ctx context.Context, miner address.Address, sectorInfos []builtin.ExtendedSectorInfo, rand abi.PoStRandomness, height abi.ChainEpoch, nwVersion network.Version) ([]builtin.PoStProof, error) //perm:admin
 
+}
+type IProofServiceProvider interface {
 	ResponseProofEvent(ctx context.Context, resp *gtypes.ResponseEvent) error                                      //perm:read
 	ListenProofEvent(ctx context.Context, policy *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) //perm:read
 }

--- a/venus-shared/api/gateway/v1/proxy_gen.go
+++ b/venus-shared/api/gateway/v1/proxy_gen.go
@@ -16,98 +16,131 @@ import (
 	gtypes "github.com/filecoin-project/venus/venus-shared/types/gateway"
 )
 
-type IProofEventStruct struct {
+type IProofClientStruct struct {
 	Internal struct {
 		ComputeProof        func(ctx context.Context, miner address.Address, sectorInfos []builtin.ExtendedSectorInfo, rand abi.PoStRandomness, height abi.ChainEpoch, nwVersion network.Version) ([]builtin.PoStProof, error) `perm:"admin"`
 		ListConnectedMiners func(ctx context.Context) ([]address.Address, error)                                                                                                                                               `perm:"admin"`
 		ListMinerConnection func(ctx context.Context, addr address.Address) (*gtypes.MinerState, error)                                                                                                                        `perm:"admin"`
-		ListenProofEvent    func(ctx context.Context, policy *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error)                                                                                                 `perm:"read"`
-		ResponseProofEvent  func(ctx context.Context, resp *gtypes.ResponseEvent) error                                                                                                                                        `perm:"read"`
 	}
 }
 
-func (s *IProofEventStruct) ComputeProof(p0 context.Context, p1 address.Address, p2 []builtin.ExtendedSectorInfo, p3 abi.PoStRandomness, p4 abi.ChainEpoch, p5 network.Version) ([]builtin.PoStProof, error) {
+func (s *IProofClientStruct) ComputeProof(p0 context.Context, p1 address.Address, p2 []builtin.ExtendedSectorInfo, p3 abi.PoStRandomness, p4 abi.ChainEpoch, p5 network.Version) ([]builtin.PoStProof, error) {
 	return s.Internal.ComputeProof(p0, p1, p2, p3, p4, p5)
 }
-func (s *IProofEventStruct) ListConnectedMiners(p0 context.Context) ([]address.Address, error) {
+func (s *IProofClientStruct) ListConnectedMiners(p0 context.Context) ([]address.Address, error) {
 	return s.Internal.ListConnectedMiners(p0)
 }
-func (s *IProofEventStruct) ListMinerConnection(p0 context.Context, p1 address.Address) (*gtypes.MinerState, error) {
+func (s *IProofClientStruct) ListMinerConnection(p0 context.Context, p1 address.Address) (*gtypes.MinerState, error) {
 	return s.Internal.ListMinerConnection(p0, p1)
 }
-func (s *IProofEventStruct) ListenProofEvent(p0 context.Context, p1 *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
+
+type IProofServiceProviderStruct struct {
+	Internal struct {
+		ListenProofEvent   func(ctx context.Context, policy *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) `perm:"read"`
+		ResponseProofEvent func(ctx context.Context, resp *gtypes.ResponseEvent) error                                        `perm:"read"`
+	}
+}
+
+func (s *IProofServiceProviderStruct) ListenProofEvent(p0 context.Context, p1 *gtypes.ProofRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
 	return s.Internal.ListenProofEvent(p0, p1)
 }
-func (s *IProofEventStruct) ResponseProofEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
+func (s *IProofServiceProviderStruct) ResponseProofEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
 	return s.Internal.ResponseProofEvent(p0, p1)
 }
 
-type IWalletEventStruct struct {
+type IProofEventStruct struct {
+	IProofClientStruct
+	IProofServiceProviderStruct
+}
+
+type IWalletClientStruct struct {
 	Internal struct {
-		AddNewAddress          func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                                             `perm:"read"`
 		ListWalletInfo         func(ctx context.Context) ([]*gtypes.WalletDetail, error)                                                                     `perm:"admin"`
 		ListWalletInfoByWallet func(ctx context.Context, wallet string) (*gtypes.WalletDetail, error)                                                        `perm:"admin"`
-		ListenWalletEvent      func(ctx context.Context, policy *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error)                           `perm:"read"`
-		RemoveAddress          func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                                             `perm:"read"`
-		ResponseWalletEvent    func(ctx context.Context, resp *gtypes.ResponseEvent) error                                                                   `perm:"read"`
-		SupportNewAccount      func(ctx context.Context, channelID types.UUID, account string) error                                                         `perm:"read"`
 		WalletHas              func(ctx context.Context, supportAccount string, addr address.Address) (bool, error)                                          `perm:"admin"`
 		WalletSign             func(ctx context.Context, account string, addr address.Address, toSign []byte, meta types.MsgMeta) (*crypto.Signature, error) `perm:"admin"`
 	}
 }
 
-func (s *IWalletEventStruct) AddNewAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
-	return s.Internal.AddNewAddress(p0, p1, p2)
-}
-func (s *IWalletEventStruct) ListWalletInfo(p0 context.Context) ([]*gtypes.WalletDetail, error) {
+func (s *IWalletClientStruct) ListWalletInfo(p0 context.Context) ([]*gtypes.WalletDetail, error) {
 	return s.Internal.ListWalletInfo(p0)
 }
-func (s *IWalletEventStruct) ListWalletInfoByWallet(p0 context.Context, p1 string) (*gtypes.WalletDetail, error) {
+func (s *IWalletClientStruct) ListWalletInfoByWallet(p0 context.Context, p1 string) (*gtypes.WalletDetail, error) {
 	return s.Internal.ListWalletInfoByWallet(p0, p1)
 }
-func (s *IWalletEventStruct) ListenWalletEvent(p0 context.Context, p1 *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
-	return s.Internal.ListenWalletEvent(p0, p1)
-}
-func (s *IWalletEventStruct) RemoveAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
-	return s.Internal.RemoveAddress(p0, p1, p2)
-}
-func (s *IWalletEventStruct) ResponseWalletEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
-	return s.Internal.ResponseWalletEvent(p0, p1)
-}
-func (s *IWalletEventStruct) SupportNewAccount(p0 context.Context, p1 types.UUID, p2 string) error {
-	return s.Internal.SupportNewAccount(p0, p1, p2)
-}
-func (s *IWalletEventStruct) WalletHas(p0 context.Context, p1 string, p2 address.Address) (bool, error) {
+func (s *IWalletClientStruct) WalletHas(p0 context.Context, p1 string, p2 address.Address) (bool, error) {
 	return s.Internal.WalletHas(p0, p1, p2)
 }
-func (s *IWalletEventStruct) WalletSign(p0 context.Context, p1 string, p2 address.Address, p3 []byte, p4 types.MsgMeta) (*crypto.Signature, error) {
+func (s *IWalletClientStruct) WalletSign(p0 context.Context, p1 string, p2 address.Address, p3 []byte, p4 types.MsgMeta) (*crypto.Signature, error) {
 	return s.Internal.WalletSign(p0, p1, p2, p3, p4)
 }
 
-type IMarketEventStruct struct {
+type IWalletServiceProviderStruct struct {
+	Internal struct {
+		AddNewAddress       func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                   `perm:"read"`
+		ListenWalletEvent   func(ctx context.Context, policy *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) `perm:"read"`
+		RemoveAddress       func(ctx context.Context, channelID types.UUID, newAddrs []address.Address) error                   `perm:"read"`
+		ResponseWalletEvent func(ctx context.Context, resp *gtypes.ResponseEvent) error                                         `perm:"read"`
+		SupportNewAccount   func(ctx context.Context, channelID types.UUID, account string) error                               `perm:"read"`
+	}
+}
+
+func (s *IWalletServiceProviderStruct) AddNewAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
+	return s.Internal.AddNewAddress(p0, p1, p2)
+}
+func (s *IWalletServiceProviderStruct) ListenWalletEvent(p0 context.Context, p1 *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
+	return s.Internal.ListenWalletEvent(p0, p1)
+}
+func (s *IWalletServiceProviderStruct) RemoveAddress(p0 context.Context, p1 types.UUID, p2 []address.Address) error {
+	return s.Internal.RemoveAddress(p0, p1, p2)
+}
+func (s *IWalletServiceProviderStruct) ResponseWalletEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
+	return s.Internal.ResponseWalletEvent(p0, p1)
+}
+func (s *IWalletServiceProviderStruct) SupportNewAccount(p0 context.Context, p1 types.UUID, p2 string) error {
+	return s.Internal.SupportNewAccount(p0, p1, p2)
+}
+
+type IWalletEventStruct struct {
+	IWalletClientStruct
+	IWalletServiceProviderStruct
+}
+
+type IMarketClientStruct struct {
 	Internal struct {
 		IsUnsealed                 func(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize) (bool, error)      `perm:"admin"`
 		ListMarketConnectionsState func(ctx context.Context) ([]gtypes.MarketConnectionState, error)                                                                                                       `perm:"admin"`
-		ListenMarketEvent          func(ctx context.Context, policy *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error)                                                                     `perm:"read"`
-		ResponseMarketEvent        func(ctx context.Context, resp *gtypes.ResponseEvent) error                                                                                                             `perm:"read"`
 		SectorsUnsealPiece         func(ctx context.Context, miner address.Address, pieceCid cid.Cid, sector storage.SectorRef, offset types.PaddedByteIndex, size abi.PaddedPieceSize, dest string) error `perm:"admin"`
 	}
 }
 
-func (s *IMarketEventStruct) IsUnsealed(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize) (bool, error) {
+func (s *IMarketClientStruct) IsUnsealed(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize) (bool, error) {
 	return s.Internal.IsUnsealed(p0, p1, p2, p3, p4, p5)
 }
-func (s *IMarketEventStruct) ListMarketConnectionsState(p0 context.Context) ([]gtypes.MarketConnectionState, error) {
+func (s *IMarketClientStruct) ListMarketConnectionsState(p0 context.Context) ([]gtypes.MarketConnectionState, error) {
 	return s.Internal.ListMarketConnectionsState(p0)
 }
-func (s *IMarketEventStruct) ListenMarketEvent(p0 context.Context, p1 *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
+func (s *IMarketClientStruct) SectorsUnsealPiece(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize, p6 string) error {
+	return s.Internal.SectorsUnsealPiece(p0, p1, p2, p3, p4, p5, p6)
+}
+
+type IMarketServiceProviderStruct struct {
+	Internal struct {
+		ListenMarketEvent   func(ctx context.Context, policy *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) `perm:"read"`
+		ResponseMarketEvent func(ctx context.Context, resp *gtypes.ResponseEvent) error                                         `perm:"read"`
+	}
+}
+
+func (s *IMarketServiceProviderStruct) ListenMarketEvent(p0 context.Context, p1 *gtypes.MarketRegisterPolicy) (<-chan *gtypes.RequestEvent, error) {
 	return s.Internal.ListenMarketEvent(p0, p1)
 }
-func (s *IMarketEventStruct) ResponseMarketEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
+func (s *IMarketServiceProviderStruct) ResponseMarketEvent(p0 context.Context, p1 *gtypes.ResponseEvent) error {
 	return s.Internal.ResponseMarketEvent(p0, p1)
 }
-func (s *IMarketEventStruct) SectorsUnsealPiece(p0 context.Context, p1 address.Address, p2 cid.Cid, p3 storage.SectorRef, p4 types.PaddedByteIndex, p5 abi.PaddedPieceSize, p6 string) error {
-	return s.Internal.SectorsUnsealPiece(p0, p1, p2, p3, p4, p5, p6)
+
+type IMarketEventStruct struct {
+	IMarketClientStruct
+	IMarketServiceProviderStruct
 }
 
 type IGatewayStruct struct {

--- a/venus-shared/api/gateway/v1/wallet_event.go
+++ b/venus-shared/api/gateway/v1/wallet_event.go
@@ -11,11 +11,18 @@ import (
 )
 
 type IWalletEvent interface {
+	IWalletClient
+	IWalletServiceProvider
+}
+
+type IWalletClient interface {
 	ListWalletInfo(ctx context.Context) ([]*gtypes.WalletDetail, error)                                                                 //perm:admin
 	ListWalletInfoByWallet(ctx context.Context, wallet string) (*gtypes.WalletDetail, error)                                            //perm:admin
 	WalletHas(ctx context.Context, supportAccount string, addr address.Address) (bool, error)                                           //perm:admin
 	WalletSign(ctx context.Context, account string, addr address.Address, toSign []byte, meta types.MsgMeta) (*crypto.Signature, error) //perm:admin
+}
 
+type IWalletServiceProvider interface {
 	ResponseWalletEvent(ctx context.Context, resp *gtypes.ResponseEvent) error                                       //perm:read
 	ListenWalletEvent(ctx context.Context, policy *gtypes.WalletRegisterPolicy) (<-chan *gtypes.RequestEvent, error) //perm:read
 	SupportNewAccount(ctx context.Context, channelID types.UUID, account string) error                               //perm:read


### PR DESCRIPTION
## Related Issues
no


## Proposed Changes
there are 2 role in `gateway` service, 
1. clients who just wish to use services.
2. clients wish to register itself to `gateway` for **providing** services

we want to split the `IxxxxEvent` interfaces into 2 part by above mentioned roles.
for 1st role, with name like: `IxxxClient`,
for 2nd role, with name like: `IxxxServiceProvider`.

this refactor makes the definition more clear on logical.



## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
    - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_, _perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _venus_, _venus-messager_, _venus-miner_, _venus-gateway_, _venus-auth_, _venus-market_, _venus-sealer_, _venus-wallet_, _venus-cluster_, _api_, _chain_, _state_, _vm_, _data transfer_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in [venus docs](https://venus.filecoin.io) or [Discussion Tutorials.](https://github.com/filecoin-project/venus/discussions/categories/tutorials)
- [ ] CI is green