### PR TITLE
Feat/dtynn/introduce dial args

### DIFF
--- a/venus-shared/api/api_info.go
+++ b/venus-shared/api/api_info.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	multiaddr "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+var (
+	infoWithToken = regexp.MustCompile("^[a-zA-Z0-9\\-_]+?\\.[a-zA-Z0-9\\-_]+?\\.([a-zA-Z0-9\\-_]+)?:.+$") // nolint:gosimple
+)
+
+func VerString(ver uint32) string {
+	return fmt.Sprintf("v%d", ver)
+}
+
+type APIInfo struct { // nolint
+	Addr  string
+	Token []byte
+}
+
+func NewAPIInfo(addr, token string) APIInfo {
+	return APIInfo{
+		Addr:  addr,
+		Token: []byte(token),
+	}
+}
+
+func ParseApiInfo(s string) APIInfo {
+	var tok []byte
+	if infoWithToken.Match([]byte(s)) {
+		sp := strings.SplitN(s, ":", 2)
+		tok = []byte(sp[0])
+		s = sp[1]
+	}
+
+	return APIInfo{
+		Addr:  s,
+		Token: tok,
+	}
+}
+
+//DialArgs parser libp2p address to http/ws protocol, the version argument can be override by address in version
+func (a APIInfo) DialArgs(version string) (string, error) {
+	return DialArgs(a.Addr, version)
+}
+
+func (a APIInfo) Host() (string, error) {
+	ma, err := multiaddr.NewMultiaddr(a.Addr)
+	if err == nil {
+		_, addr, err := manet.DialArgs(ma)
+		if err != nil {
+			return "", err
+		}
+
+		return addr, nil
+	}
+
+	spec, err := url.Parse(a.Addr)
+	if err != nil {
+		return "", err
+	}
+	return spec.Host, nil
+}
+
+func (a APIInfo) AuthHeader() http.Header {
+	if len(a.Token) != 0 {
+		headers := http.Header{}
+		a.SetAuthHeader(headers)
+		return headers
+	}
+
+	return nil
+}
+
+func (a APIInfo) SetAuthHeader(h http.Header) {
+	if len(a.Token) != 0 {
+		h.Add(AuthorizationHeader, "Bearer "+string(a.Token))
+	}
+}
+
+func DialArgs(addr, version string) (string, error) {
+	ma, err := multiaddr.NewMultiaddr(addr)
+	if err == nil {
+		_, addr, err := manet.DialArgs(ma)
+		if err != nil {
+			return "", fmt.Errorf("parser libp2p url fail %w", err)
+		}
+
+		//override version
+		val, err := ma.ValueForProtocol(ProtoVersion)
+		if err == nil {
+			version = val
+		} else if err != multiaddr.ErrProtocolNotFound {
+			return "", err
+		}
+
+		_, err = ma.ValueForProtocol(multiaddr.P_WSS)
+		if err == nil {
+			return "wss://" + addr + "/rpc/" + version, nil
+		} else if err != multiaddr.ErrProtocolNotFound {
+			return "", err
+		}
+
+		_, err = ma.ValueForProtocol(multiaddr.P_HTTPS)
+		if err == nil {
+			return "https://" + addr + "/rpc/" + version, nil
+		} else if err != multiaddr.ErrProtocolNotFound {
+			return "", err
+		}
+
+		_, err = ma.ValueForProtocol(multiaddr.P_WS)
+		if err == nil {
+			return "ws://" + addr + "/rpc/" + version, nil
+		} else if err != multiaddr.ErrProtocolNotFound {
+			return "", err
+		}
+
+		_, err = ma.ValueForProtocol(multiaddr.P_HTTP)
+		if err == nil {
+			return "http://" + addr + "/rpc/" + version, nil
+		} else if err != multiaddr.ErrProtocolNotFound {
+			return "", err
+		}
+
+		return "ws://" + addr + "/rpc/" + version, nil
+	}
+
+	_, err = url.Parse(addr)
+	if err != nil {
+		return "", fmt.Errorf("parser address fail %w", err)
+	}
+
+	return strings.TrimRight(addr, "/") + "/rpc/" + version, nil
+}

--- a/venus-shared/api/api_info_protocol.go
+++ b/venus-shared/api/api_info_protocol.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+const ProtoVersion = multiaddr.P_WSS + 1
+
+func init() {
+	err := multiaddr.AddProtocol(multiaddr.Protocol{
+		Name:  "version",
+		Code:  ProtoVersion,
+		VCode: multiaddr.CodeToVarint(ProtoVersion),
+		Size:  multiaddr.LengthPrefixedVarSize,
+		Transcoder: multiaddr.NewTranscoderFromFunctions(func(s string) ([]byte, error) {
+			if !strings.HasPrefix(s, "v") {
+				return nil, fmt.Errorf("version must start with version prefix v")
+			}
+			if len(s) < 2 {
+				return nil, fmt.Errorf("must give a specify version such as v0")
+			}
+			_, err := strconv.Atoi(s[1:])
+			if err != nil {
+				return nil, fmt.Errorf("version part must be number")
+			}
+			return []byte(s), nil
+		}, func(bytes []byte) (string, error) {
+			vStr := string(bytes)
+			if !strings.HasPrefix(vStr, "v") {
+				return "", fmt.Errorf("version must start with version prefix v")
+			}
+			if len(vStr) < 2 {
+				return "", fmt.Errorf("must give a specify version such as v0")
+			}
+			_, err := strconv.Atoi(vStr[1:])
+			if err != nil {
+				return "", fmt.Errorf("version part must be number")
+			}
+			return vStr, nil
+		}, nil),
+	})
+
+	if err != nil {
+		panic(fmt.Errorf("add `version` protocol into multiaddr: %w", err))
+	}
+}

--- a/venus-shared/api/api_info_test.go
+++ b/venus-shared/api/api_info_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAPIInfo_DialArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		want    string
+		wantErr bool
+	}{
+		{
+			"common",
+			"http://192.168.5.61:3453",
+			"http://192.168.5.61:3453/rpc/v0",
+			false,
+		},
+		{
+			"wss",
+			"/ip4/192.168.5.61/tcp/3453/wss",
+			"wss://192.168.5.61:3453/rpc/v0",
+			false,
+		},
+		{
+			"ws",
+			"/ip4/192.168.5.61/tcp/3453/ws",
+			"ws://192.168.5.61:3453/rpc/v0",
+			false,
+		},
+		{
+			"http",
+			"/ip4/192.168.5.61/tcp/34531/http",
+			"http://192.168.5.61:34531/rpc/v0",
+			false,
+		},
+		{
+			"https",
+			"/ip4/192.168.5.61/tcp/34531/https",
+			"https://192.168.5.61:34531/rpc/v0",
+			false,
+		},
+		{
+			"default to ws ",
+			"/ip4/192.168.5.61/tcp/34532",
+			"ws://192.168.5.61:34532/rpc/v0",
+			false,
+		},
+
+		{
+			"version",
+			"/ip4/192.168.5.61/tcp/34532/version/v1",
+			"ws://192.168.5.61:34532/rpc/v1",
+			false,
+		},
+		{
+			"version",
+			"/ip4/192.168.5.61/tcp/34532/version/v0",
+			"ws://192.168.5.61:34532/rpc/v0",
+			false,
+		},
+		{
+			"error version",
+			"/ip4/192.168.5.61/tcp/34532/version/1v",
+			"/ip4/192.168.5.61/tcp/34532/version/1v/rpc/v0",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "error version" {
+				fmt.Println()
+			}
+			a := APIInfo{
+				Addr: tt.addr,
+			}
+
+			got, err := a.DialArgs("v0")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DialArgs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("DialArgs() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/venus-shared/api/gateway/v0/client_gen.go
+++ b/venus-shared/api/gateway/v0/client_gen.go
@@ -32,3 +32,23 @@ func NewIGatewayRPC(ctx context.Context, addr string, requestHeader http.Header,
 
 	return &res, closer, err
 }
+
+// DialIGatewayRPC is a more convinient way of building client, as it resolves any format (url, multiaddr) of addr string.
+func DialIGatewayRPC(ctx context.Context, addr string, token string, requestHeader http.Header, opts ...jsonrpc.Option) (IGateway, jsonrpc.ClientCloser, error) {
+	ainfo := api.NewAPIInfo(addr, token)
+	endpoint, err := ainfo.DialArgs(api.VerString(MajorVersion))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get dial args: %w", err)
+	}
+
+	if requestHeader == nil {
+		requestHeader = http.Header{}
+	}
+	requestHeader.Set(api.VenusAPINamespaceHeader, APINamespace)
+	ainfo.SetAuthHeader(requestHeader)
+
+	var res IGatewayStruct
+	closer, err := jsonrpc.NewMergeClient(ctx, endpoint, MethodNamespace, api.GetInternalStructs(&res), requestHeader, opts...)
+
+	return &res, closer, err
+}

--- a/venus-shared/api/gateway/v1/client_gen.go
+++ b/venus-shared/api/gateway/v1/client_gen.go
@@ -32,3 +32,23 @@ func NewIGatewayRPC(ctx context.Context, addr string, requestHeader http.Header,
 
 	return &res, closer, err
 }
+
+// DialIGatewayRPC is a more convinient way of building client, as it resolves any format (url, multiaddr) of addr string.
+func DialIGatewayRPC(ctx context.Context, addr string, token string, requestHeader http.Header, opts ...jsonrpc.Option) (IGateway, jsonrpc.ClientCloser, error) {
+	ainfo := api.NewAPIInfo(addr, token)
+	endpoint, err := ainfo.DialArgs(api.VerString(MajorVersion))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get dial args: %w", err)
+	}
+
+	if requestHeader == nil {
+		requestHeader = http.Header{}
+	}
+	requestHeader.Set(api.VenusAPINamespaceHeader, APINamespace)
+	ainfo.SetAuthHeader(requestHeader)
+
+	var res IGatewayStruct
+	closer, err := jsonrpc.NewMergeClient(ctx, endpoint, MethodNamespace, api.GetInternalStructs(&res), requestHeader, opts...)
+
+	return &res, closer, err
+}

--- a/venus-shared/api/market/client/client_gen.go
+++ b/venus-shared/api/market/client/client_gen.go
@@ -32,3 +32,23 @@ func NewIMarketClientRPC(ctx context.Context, addr string, requestHeader http.He
 
 	return &res, closer, err
 }
+
+// DialIMarketClientRPC is a more convinient way of building client, as it resolves any format (url, multiaddr) of addr string.
+func DialIMarketClientRPC(ctx context.Context, addr string, token string, requestHeader http.Header, opts ...jsonrpc.Option) (IMarketClient, jsonrpc.ClientCloser, error) {
+	ainfo := api.NewAPIInfo(addr, token)
+	endpoint, err := ainfo.DialArgs(api.VerString(MajorVersion))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get dial args: %w", err)
+	}
+
+	if requestHeader == nil {
+		requestHeader = http.Header{}
+	}
+	requestHeader.Set(api.VenusAPINamespaceHeader, APINamespace)
+	ainfo.SetAuthHeader(requestHeader)
+
+	var res IMarketClientStruct
+	closer, err := jsonrpc.NewMergeClient(ctx, endpoint, MethodNamespace, api.GetInternalStructs(&res), requestHeader, opts...)
+
+	return &res, closer, err
+}

--- a/venus-shared/api/market/client_gen.go
+++ b/venus-shared/api/market/client_gen.go
@@ -32,3 +32,23 @@ func NewIMarketRPC(ctx context.Context, addr string, requestHeader http.Header, 
 
 	return &res, closer, err
 }
+
+// DialIMarketRPC is a more convinient way of building client, as it resolves any format (url, multiaddr) of addr string.
+func DialIMarketRPC(ctx context.Context, addr string, token string, requestHeader http.Header, opts ...jsonrpc.Option) (IMarket, jsonrpc.ClientCloser, error) {
+	ainfo := api.NewAPIInfo(addr, token)
+	endpoint, err := ainfo.DialArgs(api.VerString(MajorVersion))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get dial args: %w", err)
+	}
+
+	if requestHeader == nil {
+		requestHeader = http.Header{}
+	}
+	requestHeader.Set(api.VenusAPINamespaceHeader, APINamespace)
+	ainfo.SetAuthHeader(requestHeader)
+
+	var res IMarketStruct
+	closer, err := jsonrpc.NewMergeClient(ctx, endpoint, MethodNamespace, api.GetInternalStructs(&res), requestHeader, opts...)
+
+	return &res, closer, err
+}

--- a/venus-shared/api/messager/client_gen.go
+++ b/venus-shared/api/messager/client_gen.go
@@ -32,3 +32,23 @@ func NewIMessagerRPC(ctx context.Context, addr string, requestHeader http.Header
 
 	return &res, closer, err
 }
+
+// DialIMessagerRPC is a more convinient way of building client, as it resolves any format (url, multiaddr) of addr string.
+func DialIMessagerRPC(ctx context.Context, addr string, token string, requestHeader http.Header, opts ...jsonrpc.Option) (IMessager, jsonrpc.ClientCloser, error) {
+	ainfo := api.NewAPIInfo(addr, token)
+	endpoint, err := ainfo.DialArgs(api.VerString(MajorVersion))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get dial args: %w", err)
+	}
+
+	if requestHeader == nil {
+		requestHeader = http.Header{}
+	}
+	requestHeader.Set(api.VenusAPINamespaceHeader, APINamespace)
+	ainfo.SetAuthHeader(requestHeader)
+
+	var res IMessagerStruct
+	closer, err := jsonrpc.NewMergeClient(ctx, endpoint, MethodNamespace, api.GetInternalStructs(&res), requestHeader, opts...)
+
+	return &res, closer, err
+}

--- a/venus-shared/api/request_header.go
+++ b/venus-shared/api/request_header.go
@@ -1,3 +1,4 @@
 package api
 
 const VenusAPINamespaceHeader = "X-VENUS-API-NAMESPACE"
+const AuthorizationHeader = "Authorization"

--- a/venus-shared/api/wallet/client_gen.go
+++ b/venus-shared/api/wallet/client_gen.go
@@ -32,3 +32,23 @@ func NewIFullAPIRPC(ctx context.Context, addr string, requestHeader http.Header,
 
 	return &res, closer, err
 }
+
+// DialIFullAPIRPC is a more convinient way of building client, as it resolves any format (url, multiaddr) of addr string.
+func DialIFullAPIRPC(ctx context.Context, addr string, token string, requestHeader http.Header, opts ...jsonrpc.Option) (IFullAPI, jsonrpc.ClientCloser, error) {
+	ainfo := api.NewAPIInfo(addr, token)
+	endpoint, err := ainfo.DialArgs(api.VerString(MajorVersion))
+	if err != nil {
+		return nil, nil, fmt.Errorf("get dial args: %w", err)
+	}
+
+	if requestHeader == nil {
+		requestHeader = http.Header{}
+	}
+	requestHeader.Set(api.VenusAPINamespaceHeader, APINamespace)
+	ainfo.SetAuthHeader(requestHeader)
+
+	var res IFullAPIStruct
+	closer, err := jsonrpc.NewMergeClient(ctx, endpoint, MethodNamespace, api.GetInternalStructs(&res), requestHeader, opts...)
+
+	return &res, closer, err
+}


### PR DESCRIPTION
## Related Issues
no

## Proposed Changes
- 讲 venus-common-utils/apiinfo 引入 venus-shared
- 提供新的 `DialXXXX` 系列方法，方便使用者将任何格式的 rpc addr 与 token 作为入参传入，无需手工转换


## Additional Info
no

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
    - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_, _perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _venus_, _venus-messager_, _venus-miner_, _venus-gateway_, _venus-auth_, _venus-market_, _venus-sealer_, _venus-wallet_, _venus-cluster_, _api_, _chain_, _state_, _vm_, _data transfer_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] CI is green