### PR TITLE
refactor market api for UpdateDealPiecesStatus

### DIFF
--- a/venus-shared/api/market/api.go
+++ b/venus-shared/api/market/api.go
@@ -28,8 +28,8 @@ type IMarket interface {
 	MarketImportDealData(ctx context.Context, propcid cid.Cid, path string) error                                                                                                                               //perm:write
 	MarketListDeals(ctx context.Context, addrs []address.Address) ([]types.MarketDeal, error)                                                                                                                   //perm:read
 	MarketListRetrievalDeals(ctx context.Context, mAddr address.Address) ([]market.ProviderDealState, error)                                                                                                    //perm:read
-	MarketGetDealUpdates(ctx context.Context) (<-chan storagemarket.MinerDeal, error)                                                                                                                           //perm:read
-	MarketListIncompleteDeals(ctx context.Context, mAddr address.Address) ([]storagemarket.MinerDeal, error)                                                                                                    //perm:read
+	MarketGetDealUpdates(ctx context.Context) (<-chan market.MinerDeal, error)                                                                                                                                  //perm:read
+	MarketListIncompleteDeals(ctx context.Context, mAddr address.Address) ([]market.MinerDeal, error)                                                                                                           //perm:read
 	MarketSetAsk(ctx context.Context, mAddr address.Address, price types.BigInt, verifiedPrice types.BigInt, duration abi.ChainEpoch, minPieceSize abi.PaddedPieceSize, maxPieceSize abi.PaddedPieceSize) error //perm:admin
 	MarketGetAsk(ctx context.Context, mAddr address.Address) (*storagemarket.SignedStorageAsk, error)                                                                                                           //perm:read
 	MarketListAsk(ctx context.Context) ([]*storagemarket.SignedStorageAsk, error)                                                                                                                               //perm:read
@@ -133,7 +133,7 @@ type IMarket interface {
 	GetDeals(ctx context.Context, miner address.Address, pageIndex, pageSize int) ([]*market.DealInfo, error)                                              //perm:read
 	AssignUnPackedDeals(ctx context.Context, miner address.Address, ssize abi.SectorSize, spec *market.GetDealSpec) ([]*market.DealInfoIncludePath, error) //perm:write
 	GetUnPackedDeals(ctx context.Context, miner address.Address, spec *market.GetDealSpec) ([]*market.DealInfoIncludePath, error)                          //perm:read
-	UpdateStorageDealStatus(ctx context.Context, dealProposalCid cid.Cid, state storagemarket.StorageDealStatus) error                                     //perm:write
+	UpdateStorageDealStatus(ctx context.Context, dealProposalCid cid.Cid, state storagemarket.StorageDealStatus, pieceState string) error                  //perm:write
 	//market event
 	ResponseMarketEvent(ctx context.Context, resp *gateway.ResponseEvent) error                                        //perm:read
 	ListenMarketEvent(ctx context.Context, policy *gateway.MarketRegisterPolicy) (<-chan *gateway.RequestEvent, error) //perm:read

--- a/venus-shared/api/market/method.md
+++ b/venus-shared/api/market/method.md
@@ -817,6 +817,7 @@ Response:
   "Client": "12D3KooWGzxzKZYveHXtpG6AsrUJBcWxHBFS2HsEoGTxrMLvKXtf",
   "State": 42,
   "PiecePath": "/some/path",
+  "PayloadSize": 1024,
   "MetadataPath": "/some/path",
   "SlashEpoch": 10101,
   "FastRetrieval": true,
@@ -840,6 +841,8 @@ Response:
     "ID": 3
   },
   "SectorNumber": 9,
+  "Offset": 1032,
+  "PieceStatus": "string value",
   "InboundCAR": "string value"
 }
 ```
@@ -1054,6 +1057,7 @@ Response:
     "Client": "12D3KooWGzxzKZYveHXtpG6AsrUJBcWxHBFS2HsEoGTxrMLvKXtf",
     "State": 42,
     "PiecePath": "/some/path",
+    "PayloadSize": 1024,
     "MetadataPath": "/some/path",
     "SlashEpoch": 10101,
     "FastRetrieval": true,
@@ -1077,6 +1081,8 @@ Response:
       "ID": 3
     },
     "SectorNumber": 9,
+    "Offset": 1032,
+    "PieceStatus": "string value",
     "InboundCAR": "string value"
   }
 ]
@@ -1666,7 +1672,8 @@ Inputs:
   {
     "/": "bafy2bzacea3wsdh6y3a36tb3skempjoxqpuyompjbmfeyf34fi3uy6uue42v4"
   },
-  42
+  42,
+  "string value"
 ]
 ```
 

--- a/venus-shared/api/market/mock/mock_imarket.go
+++ b/venus-shared/api/market/mock/mock_imarket.go
@@ -577,10 +577,10 @@ func (mr *MockIMarketMockRecorder) MarketGetAsk(arg0, arg1 interface{}) *gomock.
 }
 
 // MarketGetDealUpdates mocks base method.
-func (m *MockIMarket) MarketGetDealUpdates(arg0 context.Context) (<-chan storagemarket.MinerDeal, error) {
+func (m *MockIMarket) MarketGetDealUpdates(arg0 context.Context) (<-chan market.MinerDeal, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarketGetDealUpdates", arg0)
-	ret0, _ := ret[0].(<-chan storagemarket.MinerDeal)
+	ret0, _ := ret[0].(<-chan market.MinerDeal)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -681,10 +681,10 @@ func (mr *MockIMarketMockRecorder) MarketListDeals(arg0, arg1 interface{}) *gomo
 }
 
 // MarketListIncompleteDeals mocks base method.
-func (m *MockIMarket) MarketListIncompleteDeals(arg0 context.Context, arg1 address.Address) ([]storagemarket.MinerDeal, error) {
+func (m *MockIMarket) MarketListIncompleteDeals(arg0 context.Context, arg1 address.Address) ([]market.MinerDeal, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarketListIncompleteDeals", arg0, arg1)
-	ret0, _ := ret[0].([]storagemarket.MinerDeal)
+	ret0, _ := ret[0].([]market.MinerDeal)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1047,15 +1047,15 @@ func (mr *MockIMarketMockRecorder) UpdateDealStatus(arg0, arg1, arg2, arg3 inter
 }
 
 // UpdateStorageDealStatus mocks base method.
-func (m *MockIMarket) UpdateStorageDealStatus(arg0 context.Context, arg1 cid.Cid, arg2 uint64) error {
+func (m *MockIMarket) UpdateStorageDealStatus(arg0 context.Context, arg1 cid.Cid, arg2 uint64, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStorageDealStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateStorageDealStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateStorageDealStatus indicates an expected call of UpdateStorageDealStatus.
-func (mr *MockIMarketMockRecorder) UpdateStorageDealStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockIMarketMockRecorder) UpdateStorageDealStatus(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStorageDealStatus", reflect.TypeOf((*MockIMarket)(nil).UpdateStorageDealStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStorageDealStatus", reflect.TypeOf((*MockIMarket)(nil).UpdateStorageDealStatus), arg0, arg1, arg2, arg3)
 }

--- a/venus-shared/api/market/proxy_gen.go
+++ b/venus-shared/api/market/proxy_gen.go
@@ -58,14 +58,14 @@ type IMarketStruct struct {
 		MarketCancelDataTransfer               func(ctx context.Context, transferID datatransfer.TransferID, otherPeer peer.ID, isInitiator bool) error                                                                                            `perm:"write"`
 		MarketDataTransferUpdates              func(ctx context.Context) (<-chan market.DataTransferChannel, error)                                                                                                                                `perm:"write"`
 		MarketGetAsk                           func(ctx context.Context, mAddr address.Address) (*storagemarket.SignedStorageAsk, error)                                                                                                           `perm:"read"`
-		MarketGetDealUpdates                   func(ctx context.Context) (<-chan storagemarket.MinerDeal, error)                                                                                                                                   `perm:"read"`
+		MarketGetDealUpdates                   func(ctx context.Context) (<-chan market.MinerDeal, error)                                                                                                                                          `perm:"read"`
 		MarketGetReserved                      func(ctx context.Context, addr address.Address) (types.BigInt, error)                                                                                                                               `perm:"sign"`
 		MarketGetRetrievalAsk                  func(ctx context.Context, mAddr address.Address) (*retrievalmarket.Ask, error)                                                                                                                      `perm:"read"`
 		MarketImportDealData                   func(ctx context.Context, propcid cid.Cid, path string) error                                                                                                                                       `perm:"write"`
 		MarketListAsk                          func(ctx context.Context) ([]*storagemarket.SignedStorageAsk, error)                                                                                                                                `perm:"read"`
 		MarketListDataTransfers                func(ctx context.Context) ([]market.DataTransferChannel, error)                                                                                                                                     `perm:"write"`
 		MarketListDeals                        func(ctx context.Context, addrs []address.Address) ([]types.MarketDeal, error)                                                                                                                      `perm:"read"`
-		MarketListIncompleteDeals              func(ctx context.Context, mAddr address.Address) ([]storagemarket.MinerDeal, error)                                                                                                                 `perm:"read"`
+		MarketListIncompleteDeals              func(ctx context.Context, mAddr address.Address) ([]market.MinerDeal, error)                                                                                                                        `perm:"read"`
 		MarketListRetrievalAsk                 func(ctx context.Context) ([]*market.RetrievalAsk, error)                                                                                                                                           `perm:"read"`
 		MarketListRetrievalDeals               func(ctx context.Context, mAddr address.Address) ([]market.ProviderDealState, error)                                                                                                                `perm:"read"`
 		MarketPendingDeals                     func(ctx context.Context) ([]market.PendingDealInfo, error)                                                                                                                                         `perm:"write"`
@@ -90,7 +90,7 @@ type IMarketStruct struct {
 		SectorSetExpectedSealDuration          func(context.Context, time.Duration) error                                                                                                                                                          `perm:"write"`
 		UpdateDealOnPacking                    func(ctx context.Context, miner address.Address, dealID abi.DealID, sectorid abi.SectorNumber, offset abi.PaddedPieceSize) error                                                                    `perm:"write"`
 		UpdateDealStatus                       func(ctx context.Context, miner address.Address, dealID abi.DealID, pieceStatus string) error                                                                                                       `perm:"write"`
-		UpdateStorageDealStatus                func(ctx context.Context, dealProposalCid cid.Cid, state storagemarket.StorageDealStatus) error                                                                                                     `perm:"write"`
+		UpdateStorageDealStatus                func(ctx context.Context, dealProposalCid cid.Cid, state storagemarket.StorageDealStatus, pieceState string) error                                                                                  `perm:"write"`
 	}
 }
 
@@ -200,7 +200,7 @@ func (s *IMarketStruct) MarketDataTransferUpdates(p0 context.Context) (<-chan ma
 func (s *IMarketStruct) MarketGetAsk(p0 context.Context, p1 address.Address) (*storagemarket.SignedStorageAsk, error) {
 	return s.Internal.MarketGetAsk(p0, p1)
 }
-func (s *IMarketStruct) MarketGetDealUpdates(p0 context.Context) (<-chan storagemarket.MinerDeal, error) {
+func (s *IMarketStruct) MarketGetDealUpdates(p0 context.Context) (<-chan market.MinerDeal, error) {
 	return s.Internal.MarketGetDealUpdates(p0)
 }
 func (s *IMarketStruct) MarketGetReserved(p0 context.Context, p1 address.Address) (types.BigInt, error) {
@@ -221,7 +221,7 @@ func (s *IMarketStruct) MarketListDataTransfers(p0 context.Context) ([]market.Da
 func (s *IMarketStruct) MarketListDeals(p0 context.Context, p1 []address.Address) ([]types.MarketDeal, error) {
 	return s.Internal.MarketListDeals(p0, p1)
 }
-func (s *IMarketStruct) MarketListIncompleteDeals(p0 context.Context, p1 address.Address) ([]storagemarket.MinerDeal, error) {
+func (s *IMarketStruct) MarketListIncompleteDeals(p0 context.Context, p1 address.Address) ([]market.MinerDeal, error) {
 	return s.Internal.MarketListIncompleteDeals(p0, p1)
 }
 func (s *IMarketStruct) MarketListRetrievalAsk(p0 context.Context) ([]*market.RetrievalAsk, error) {
@@ -296,6 +296,6 @@ func (s *IMarketStruct) UpdateDealOnPacking(p0 context.Context, p1 address.Addre
 func (s *IMarketStruct) UpdateDealStatus(p0 context.Context, p1 address.Address, p2 abi.DealID, p3 string) error {
 	return s.Internal.UpdateDealStatus(p0, p1, p2, p3)
 }
-func (s *IMarketStruct) UpdateStorageDealStatus(p0 context.Context, p1 cid.Cid, p2 storagemarket.StorageDealStatus) error {
-	return s.Internal.UpdateStorageDealStatus(p0, p1, p2)
+func (s *IMarketStruct) UpdateStorageDealStatus(p0 context.Context, p1 cid.Cid, p2 storagemarket.StorageDealStatus, p3 string) error {
+	return s.Internal.UpdateStorageDealStatus(p0, p1, p2, p3)
 }


### PR DESCRIPTION

## Proposed Changes
`./venus-market storage-deals list`命令需要 列出订单时能够显示订单的piece state
`./venus-market storage-deals update` 命令需要能够更新订单的piece state

所以,需要将
`MarketListIncompleteDeals`,`MarketGetDealUpdates`,`UpdateStorageDealStatus`,
接口修改为:
	MarketListIncompleteDeals(ctx context.Context, mAddr address.Address) ([]market.MinerDeal, error)      
	MarketGetDealUpdates(ctx context.Context) (<-chan market.MinerDeal, error)       
	UpdateStorageDealStatus(ctx context.Context, dealProposalCid cid.Cid, state storagemarket.StorageDealStatus, pieceState string) error
