### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/swarm_integration_test.go
+++ b/cmd/swarm_integration_test.go
@@ -2,15 +2,13 @@ package cmd_test
 
 import (
 	"context"
-	"io/ioutil"
 	"testing"
 
-	th "github.com/filecoin-project/venus/pkg/testhelpers"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/filecoin-project/venus/app/node/test"
+	th "github.com/filecoin-project/venus/pkg/testhelpers"
 	tf "github.com/filecoin-project/venus/pkg/testhelpers/testflags"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSwarmConnectPeersValid(t *testing.T) {
@@ -61,8 +59,7 @@ func TestPersistId(t *testing.T) {
 	tf.IntegrationTest(t)
 
 	// we need to control this
-	dir, err := ioutil.TempDir("", "go-fil-test")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	// Start a demon in dir
 	d1 := th.NewDaemon(t, th.ContainerDir(dir)).Start()

--- a/pkg/repo/fskeystore/fskeystore_test.go
+++ b/pkg/repo/fskeystore/fskeystore_test.go
@@ -5,12 +5,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"sort"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 
@@ -48,10 +45,7 @@ func assertDirContents(dir string, exp []string) error {
 
 func TestKeystoreBasics(t *testing.T) {
 	tf.UnitTest(t)
-	tdir, err := ioutil.TempDir("", "keystore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tdir := t.TempDir()
 
 	ks, err := NewFSKeystore(tdir)
 	if err != nil {
@@ -169,12 +163,7 @@ func TestKeystoreBasics(t *testing.T) {
 func TestInvalidKeyFiles(t *testing.T) {
 	tf.UnitTest(t)
 
-	tdir, err := ioutil.TempDir("", "keystore-test")
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer assert.NoError(t, os.RemoveAll(tdir))
+	tdir := t.TempDir()
 
 	ks, err := NewFSKeystore(tdir)
 	if err != nil {
@@ -223,10 +212,7 @@ func TestInvalidKeyFiles(t *testing.T) {
 func TestNonExistingKey(t *testing.T) {
 	tf.UnitTest(t)
 
-	tdir, err := ioutil.TempDir("", "keystore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tdir := t.TempDir()
 
 	ks, err := NewFSKeystore(tdir)
 	if err != nil {

--- a/pkg/repo/testing.go
+++ b/pkg/repo/testing.go
@@ -15,12 +15,6 @@ func RequireMakeTempDir(t *testing.T, dirname string) string {
 	return newdir
 }
 
-// RequireRemoveAll ensures that the error condition is checked when we clean up
-// after creating a temporary directory.
-func RequireRemoveAll(t *testing.T, path string) {
-	require.NoError(t, os.RemoveAll(path))
-}
-
 // RequireOpenTempFile is a shortcut for opening a given temp file with a given
 // suffix, then returning both a filename and a file pointer.
 func RequireOpenTempFile(t *testing.T, suffix string) (*os.File, string) {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```


## Additional Info
<!-- callouts, links to documentation, and etc-->
https://pkg.go.dev/testing#T.TempDir

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <#issue number> <area>: <change being made>`
    - example: ` fix: #1234 mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_, _misc_, _perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _venus_, _venus-messager_, _venus-miner_, _venus-gateway_, _venus-auth_, _venus-market_, _venus-sealer_, _venus-wallet_, _venus-cluster_, _api_, _chain_, _state_, _vm_, _data transfer_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in [venus docs](https://venus.filecoin.io) or [Discussion Tutorials.](https://github.com/filecoin-project/venus/discussions/categories/tutorials)
- [x] CI is green