### PR TITLE
fix: panic caused by `state power` cli if  power of miner not exist

### DIFF
--- a/cmd/state.go
+++ b/cmd/state.go
@@ -159,6 +159,9 @@ var statePowerCmd = &cmds.Command{
 		tp := power.TotalPower
 		if len(req.Arguments) == 1 {
 			mp := power.MinerPower
+			if !power.HasMinPower {
+				mp.QualityAdjPower = big.NewInt(0)
+			}
 			percI := big.Div(big.Mul(mp.QualityAdjPower, big.NewInt(1000000)), tp.QualityAdjPower)
 			writer.Printf("%s(%s) / %s(%s) ~= %0.4f%"+
 				"%\n", mp.QualityAdjPower.String(), types.SizeStr(mp.QualityAdjPower), tp.QualityAdjPower.String(), types.SizeStr(tp.QualityAdjPower), float64(percI.Int64())/10000)


### PR DESCRIPTION
fix: cli: panic caused by `state power` cli if  power of miner not exist
would fixes https://github.com/filecoin-project/venus/issues/5016