### PR TITLE
fix: command line: list miner control addresses get an error if owner is multi-sig

### DIFF
--- a/cmd/miner_actor.go
+++ b/cmd/miner_actor.go
@@ -493,17 +493,13 @@ var actorControlList = &cmds.Command{
 		}
 
 		printKey := func(name string, a address.Address) {
-			b, err := env.(*node.Env).WalletAPI.WalletBalance(ctx, a)
-			if err != nil {
-				_ = re.Emit(fmt.Sprintf("%s  %s: error getting balance: %s", name, a, err))
-				return
-			}
 			api := env.(*node.Env).ChainAPI
 			actor, err := api.StateGetActor(ctx, a, types.EmptyTSK)
 			if err != nil {
 				_ = re.Emit(fmt.Sprintf("get actor(%s) failed: %s", a, err))
 				return
 			}
+			b := actor.Balance
 
 			var k address.Address
 			// param 'a` maybe a 'robust', in that case, 'StateAccountKey' returns an error.

--- a/cmd/miner_actor.go
+++ b/cmd/miner_actor.go
@@ -501,7 +501,7 @@ var actorControlList = &cmds.Command{
 			api := env.(*node.Env).ChainAPI
 			actor, err := api.StateGetActor(ctx, a, types.EmptyTSK)
 			if err != nil {
-				_ = re.Emit(fmt.Sprintf("get actor(%s) failed: %s", a, err.Error))
+				_ = re.Emit(fmt.Sprintf("get actor(%s) failed: %s", a, err))
 				return
 			}
 

--- a/cmd/miner_actor.go
+++ b/cmd/miner_actor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/venus/cmd/tablewriter"
 	"github.com/filecoin-project/venus/venus-shared/actors"
 	"github.com/filecoin-project/venus/venus-shared/actors/adt"
+	"github.com/filecoin-project/venus/venus-shared/actors/builtin"
 	"github.com/filecoin-project/venus/venus-shared/actors/builtin/miner"
 	"github.com/filecoin-project/venus/venus-shared/types"
 )
@@ -497,13 +498,26 @@ var actorControlList = &cmds.Command{
 				_ = re.Emit(fmt.Sprintf("%s  %s: error getting balance: %s", name, a, err))
 				return
 			}
-
-			k, err := env.(*node.Env).ChainAPI.StateAccountKey(ctx, a, types.EmptyTSK)
+			api := env.(*node.Env).ChainAPI
+			actor, err := api.StateGetActor(ctx, a, types.EmptyTSK)
 			if err != nil {
-				_ = re.Emit(fmt.Sprintf("%s  %s: error getting account key: %s", name, a, err))
+				_ = re.Emit(fmt.Sprintf("get actor(%s) failed: %s", a, err.Error))
 				return
 			}
 
+			var k address.Address
+			// param 'a` maybe a 'robust', in that case, 'StateAccountKey' returns an error.
+			if builtin.IsAccountActor(actor.Code) {
+				if k, err = api.StateAccountKey(ctx, a, types.EmptyTSK); err != nil {
+					_ = re.Emit(fmt.Sprintf("%s  %s: error getting account key: %s", name, a, err))
+					return
+				}
+			} else { // if builtin.IsMultisigActor(actor.Code)
+				if k, err = api.StateLookupRobustAddress(ctx, a, types.EmptyTSK); err != nil {
+					_ = re.Emit(fmt.Sprintf("%s  %s: error getting robust address: %s", name, a, err))
+					return
+				}
+			}
 			kstr := k.String()
 			if !req.Options["verbose"].(bool) {
 				kstr = kstr[:9] + "..."


### PR DESCRIPTION
fix: command line: list miner control addresses get an error if owner/worker is robust(not account)
would fixes https://github.com/filecoin-project/venus/issues/5041