### PR TITLE
fix: 默认输出当前网络版本的actor cids / actor-cids cli command now defaults to current network version

### DIFF
--- a/cmd/state.go
+++ b/cmd/state.go
@@ -611,26 +611,24 @@ var stateSysActorCIDsCmd = &cmds.Command{
 		Tagline: "Returns the built-in actor bundle manifest ID & system actor cids",
 	},
 	Options: []cmds.Option{
-		cmds.UintOption("network-version", "specify network version").WithDefault(uint(constants.NewestNetworkVersion)),
+		cmds.UintOption("network-version", "specify network version"),
 	},
 	Run: func(req *cmds.Request, re cmds.ResponseEmitter, env cmds.Environment) error {
 		ctx := req.Context
-		ts, err := env.(*node.Env).ChainAPI.ChainHead(ctx)
-		if err != nil {
-			return err
-		}
 
-		nv, err := env.(*node.Env).ChainAPI.StateNetworkVersion(ctx, ts.Key())
-		if err != nil {
-			return err
-		}
-
+		var nv network.Version
+		var err error
 		targetNV, ok := req.Options["network-version"].(uint)
 		if ok {
 			nv = network.Version(targetNV)
+		} else {
+			nv, err = env.(*node.Env).ChainAPI.StateNetworkVersion(ctx, types.EmptyTSK)
+			if err != nil {
+				return err
+			}
 		}
-		buf := new(bytes.Buffer)
 
+		buf := new(bytes.Buffer)
 		buf.WriteString(fmt.Sprintf("Network Version: %d\n", nv))
 
 		actorVersion, err := actors.VersionForNetwork(nv)


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close https://github.com/filecoin-project/venus/issues/5297

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
