### PR TITLE
fix: Register custom proof-types to specactor v8 / actor-v8的自定义proof-type注册问题

### DIFF
--- a/venus-shared/actors/policy/policy.go
+++ b/venus-shared/actors/policy/policy.go
@@ -60,6 +60,8 @@ import (
 	miner8 "github.com/filecoin-project/go-state-types/builtin/v8/miner"
 	verifreg8 "github.com/filecoin-project/go-state-types/builtin/v8/verifreg"
 
+	specsMiner8 "github.com/filecoin-project/specs-actors/v8/actors/builtin/miner"
+
 	paych8 "github.com/filecoin-project/go-state-types/builtin/v8/paych"
 )
 
@@ -95,6 +97,7 @@ func SetSupportedProofTypes(types ...abi.RegisteredSealProof) {
 	miner7.PreCommitSealProofTypesV8 = make(map[abi.RegisteredSealProof]struct{}, len(types))
 
 	miner8.PreCommitSealProofTypesV8 = make(map[abi.RegisteredSealProof]struct{}, len(types))
+	specsMiner8.PreCommitSealProofTypesV8 = make(map[abi.RegisteredSealProof]struct{}, len(types))
 
 	AddSupportedProofTypes(types...)
 }
@@ -153,6 +156,7 @@ func AddSupportedProofTypes(types ...abi.RegisteredSealProof) {
 		miner7.WindowPoStProofTypes[wpp] = struct{}{}
 
 		miner8.PreCommitSealProofTypesV8[t+abi.RegisteredSealProof_StackedDrg2KiBV1_1] = struct{}{}
+		specsMiner8.PreCommitSealProofTypesV8[t+abi.RegisteredSealProof_StackedDrg2KiBV1_1] = struct{}{}
 		wpp, err = t.RegisteredWindowPoStProof()
 		if err != nil {
 			// Fine to panic, this is a test-only method
@@ -160,7 +164,7 @@ func AddSupportedProofTypes(types ...abi.RegisteredSealProof) {
 		}
 
 		miner8.WindowPoStProofTypes[wpp] = struct{}{}
-
+		specsMiner8.WindowPoStProofTypes[wpp] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

fix #5249

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

这个问题根本上应该是specs-actors v8中的bug. specs-actors/v8@v8.0.1/actors/builtin/miner/miner_actor.go#L110:
func (a Actor) Constructor(rt Runtime, params *ConstructorParams) *abi.EmptyValue {
        // ...  ...
	if !CanWindowPoStProof(params.WindowPoStProofType) {
		rt.Abortf(exitcode.ErrIllegalArgument, "proof type %d not allowed for new miner actors", params.WindowPoStProofType)
	}
}
这里用的是自己包中的函数和对象（WindowPoStProofTypes）；

但是lotus/venus 都将 prooftype 注册到了 go-state-types/builtin/v8/miner这里的 WindowPoStProofTypes.

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
