### PR TITLE
chore: ignore some fields in the parameters structure of the config.json

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -121,8 +121,7 @@ func initRun(req *cmds.Request) error {
 	cfg := rep.Config()
 	network, _ := req.Options[Network].(string)
 	if err := networks.SetConfigFromOptions(cfg, network); err != nil {
-		log.Errorf("Error setting config %s", err)
-		return err
+		return fmt.Errorf("setting config %v", err)
 	}
 	// genesis node
 	if mkGen, ok := req.Options[makeGenFlag].(string); ok {
@@ -170,6 +169,11 @@ func daemonRun(req *cmds.Request, re cmds.ResponseEmitter) error {
 	}
 
 	config := rep.Config()
+	if err := networks.SetConfigFromNetworkType(config, config.NetworkParams.NetworkType); err != nil {
+		return fmt.Errorf("set config failed %v %v", config.NetworkParams.NetworkType, err)
+	}
+	log.Infof("network params: %+v", config.NetworkParams)
+	log.Infof("upgrade params: %+v", config.NetworkParams.ForkUpgradeParam)
 
 	if err := actors.SetNetworkBundle(int(config.NetworkParams.NetworkType)); err != nil {
 		return err

--- a/fixtures/networks/network_parse.go
+++ b/fixtures/networks/network_parse.go
@@ -22,22 +22,39 @@ func GetNetworkFromName(name string) (types.NetworkType, error) {
 	return nt, nil
 }
 
-func SetConfigFromOptions(cfg *config.Config, network string) error {
-	netcfg, err := GetNetworkConfig(network)
+func SetConfigFromOptions(cfg *config.Config, networkName string) error {
+	netcfg, err := GetNetworkConfig(networkName)
 	if err != nil {
 		return err
 	}
-	if netcfg != nil {
-		cfg.Bootstrap = &netcfg.Bootstrap
-		cfg.NetworkParams = &netcfg.Network
-	}
+	cfg.Bootstrap = &netcfg.Bootstrap
+	cfg.NetworkParams = &netcfg.Network
 	return nil
 }
 
-func GetNetworkConfig(network string) (*NetworkConf, error) {
-	networkType, err := GetNetworkFromName(network)
+func SetConfigFromNetworkType(cfg *config.Config, networkType types.NetworkType) error {
+	netcfg, err := GetNetworkConfig(networkType)
 	if err != nil {
-		return nil, err
+		return err
+	}
+	cfg.NetworkParams = &netcfg.Network
+	return nil
+}
+
+func GetNetworkConfig(network interface{}) (*NetworkConf, error) {
+	var networkType types.NetworkType
+	var err error
+
+	switch val := network.(type) {
+	case types.NetworkType:
+		networkType = val
+	case string:
+		networkType, err = GetNetworkFromName(val)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("not expect type %T %v", network, network)
 	}
 
 	switch networkType {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -250,18 +250,18 @@ func newDefaultMessagePoolConfig() *MessagePoolConfig {
 
 // NetworkParamsConfig record netork parameters
 type NetworkParamsConfig struct {
-	DevNet                  bool                         `json:"devNet"`
+	DevNet                  bool                         `json:"-"`
 	NetworkType             types.NetworkType            `json:"networkType"`
-	GenesisNetworkVersion   network.Version              `json:"genesisNetworkVersion"`
-	ConsensusMinerMinPower  uint64                       `json:"consensusMinerMinPower"` // uint64 goes up to 18 EiB
-	MinVerifiedDealSize     int64                        `json:"minVerifiedDealSize"`
-	ReplaceProofTypes       []abi.RegisteredSealProof    `json:"replaceProofTypes"`
-	BlockDelay              uint64                       `json:"blockDelay"`
-	DrandSchedule           map[abi.ChainEpoch]DrandEnum `json:"drandSchedule"`
-	ForkUpgradeParam        *ForkUpgradeConfig           `json:"forkUpgradeParam"`
-	AddressNetwork          address.Network              `json:"addressNetwork"`
-	PreCommitChallengeDelay abi.ChainEpoch               `json:"preCommitChallengeDelay"`
-	PropagationDelaySecs    uint64                       `json:"propagationDelaySecs"`
+	AddressNetwork          address.Network              `json:"-"`
+	GenesisNetworkVersion   network.Version              `json:"-"`
+	ConsensusMinerMinPower  uint64                       `json:"-"` // uint64 goes up to 18 EiB
+	MinVerifiedDealSize     int64                        `json:"-"`
+	ReplaceProofTypes       []abi.RegisteredSealProof    `json:"-"`
+	BlockDelay              uint64                       `json:"-"`
+	DrandSchedule           map[abi.ChainEpoch]DrandEnum `json:"-"`
+	ForkUpgradeParam        *ForkUpgradeConfig           `json:"-"`
+	PreCommitChallengeDelay abi.ChainEpoch               `json:"-"`
+	PropagationDelaySecs    uint64                       `json:"-"`
 }
 
 // ForkUpgradeConfig record upgrade parameters

--- a/pkg/migration/migrate.go
+++ b/pkg/migration/migrate.go
@@ -32,6 +32,7 @@ var versionMap = []versionInfo{
 	{version: 7, upgrade: Version7Upgrade},
 	{version: 8, upgrade: Version8Upgrade},
 	{version: 9, upgrade: Version9Upgrade},
+	{version: 10, upgrade: Version10Upgrade},
 }
 
 // TryToMigrate used to migrate data(db,config,file,etc) in local repo
@@ -344,4 +345,23 @@ func Version9Upgrade(repoPath string) (err error) {
 	}
 
 	return repo.WriteVersion(repoPath, 9)
+}
+
+// Version10Upgrade will ignore some fields in the parameters structure of the config.json file
+func Version10Upgrade(repoPath string) (err error) {
+	var fsrRepo repo.Repo
+	if fsrRepo, err = repo.OpenFSRepo(repoPath, 9); err != nil {
+		return
+	}
+	cfg := fsrRepo.Config()
+
+	if err = fsrRepo.ReplaceConfig(cfg); err != nil {
+		return
+	}
+
+	if err = fsrRepo.Close(); err != nil {
+		return
+	}
+
+	return repo.WriteVersion(repoPath, 10)
 }

--- a/pkg/migration/migrate_test.go
+++ b/pkg/migration/migrate_test.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/filecoin-project/venus/fixtures/networks"
@@ -38,7 +39,12 @@ func TestMigration(t *testing.T) {
 		fsRepo, err := repo.OpenFSRepo(repoPath, repo.LatestVersion)
 		assert.Nil(t, err)
 		newCfg := fsRepo.Config()
-		assert.Equal(t, paramsCfg.GenesisNetworkVersion, newCfg.NetworkParams.GenesisNetworkVersion)
-		assert.EqualValuesf(t, paramsCfg.ForkUpgradeParam, newCfg.NetworkParams.ForkUpgradeParam, fmt.Sprintf("current network type %d", paramsCfg.NetworkType))
+		assert.Equal(t, paramsCfg.NetworkType, newCfg.NetworkParams.NetworkType)
+		assert.EqualValuesf(t, config.NewDefaultConfig().NetworkParams.ForkUpgradeParam, newCfg.NetworkParams.ForkUpgradeParam, fmt.Sprintf("current network type %d", paramsCfg.NetworkType))
+
+		cfgTmp, err := config.ReadFile(filepath.Join(repoPath, "config.json"))
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), cfgTmp.NetworkParams.BlockDelay)
+		assert.Equal(t, paramsCfg.NetworkType, cfgTmp.NetworkParams.NetworkType)
 	}
 }

--- a/pkg/repo/fsrepo.go
+++ b/pkg/repo/fsrepo.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Version is the version of repo schema that this code understands.
-const LatestVersion uint = 9
+const LatestVersion uint = 10
 
 const (
 	// apiFile is the filename containing the filecoin node's api address.


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close https://github.com/filecoin-project/venus/issues/5491

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->

### 配置文件

`config.json` 中 `parameters`只保留`networkType`字段，其余字段将会被移除
```
"parameters": {
        "networkType": 1
},
```

### 日志

启动时增加日志输出：
```
network params: &{DevNet:false NetworkType:1 AddressNetwork:0 GenesisNetworkVersion:0 ConsensusMinerMinPower:10995116277760 MinVerifiedDealSize:1048576 ReplaceProofTypes:[3 4] BlockDelay:30 DrandSchedule:map[0:5 51000:1] ForkUpgradeParam:0xc00019e2c0 PreCommitChallengeDelay:150 PropagationDelaySecs:10}
upgrade params: &{UpgradeSmokeHeight:51000 UpgradeBreezeHeight:41280 UpgradeIgnitionHeight:94000 UpgradeLiftoffHeight:148888 UpgradeAssemblyHeight:138720 UpgradeRefuelHeight:130800 UpgradeTapeHeight:140760 UpgradeKumquatHeight:170000 UpgradePriceListOopsHeight:0 BreezeGasTampingDuration:120 UpgradeCalicoHeight:265200 UpgradePersianHeight:272400 UpgradeOrangeHeight:336458 UpgradeClausHeight:343200 UpgradeTrustHeight:550321 UpgradeNorwegianHeight:665280 UpgradeTurboHeight:712320 UpgradeHyperdriveHeight:892800 UpgradeChocolateHeight:1231620 UpgradeOhSnapHeight:1594680 UpgradeSkyrHeight:1960320 UpgradeSharkHeight:2383680}
```

## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
