### PR TITLE
fix: forcenet use testing bundle

### DIFF
--- a/venus-shared/actors/builtin_actors.go
+++ b/venus-shared/actors/builtin_actors.go
@@ -57,9 +57,12 @@ func init() {
 func SetNetworkBundle(networkType int) error {
 	networkBundle := ""
 	switch networkType {
-	// case types.Network2k, types.NetworkForce:
-	case 0x2, 0x7:
+	// case types.Network2k:
+	case 0x2:
 		networkBundle = "devnet"
+	// types.NetworkForce
+	case 0x7:
+		networkBundle = "testing"
 	// case types.NetworkButterfly:
 	case 0x8:
 		networkBundle = "butterflynet"

--- a/venus-shared/types/api_types.go
+++ b/venus-shared/types/api_types.go
@@ -77,6 +77,7 @@ const (
 	NetworkNameButterfly   NetworkName = "butterflynet"
 	NetworkNameInterop     NetworkName = "interopnet"
 	NetworkNameIntegration NetworkName = "integrationnet"
+	NetworkNameForce       NetworkName = "forcenet"
 )
 
 type NetworkType int

--- a/venus-shared/utils/utils.go
+++ b/venus-shared/utils/utils.go
@@ -14,6 +14,7 @@ var NetworkNameWithNetworkType = map[types.NetworkName]types.NetworkType{
 	types.NetworkNameButterfly:   types.NetworkButterfly,
 	types.NetworkNameInterop:     types.NetworkInterop,
 	types.NetworkNameIntegration: types.Integrationnet,
+	types.NetworkNameForce:       types.NetworkForce,
 }
 
 var NetworkTypeWithNetworkName = func() map[types.NetworkType]types.NetworkName {
@@ -33,7 +34,7 @@ func NetworkNameToNetworkType(networkName types.NetworkName) (types.NetworkType,
 	if ok {
 		return nt, nil
 	}
-	// 2k and force networks do not have exact network names
+	// 2k network do not have exact network names
 	return types.Network2k, nil
 }
 
@@ -43,7 +44,7 @@ func NetworkTypeToNetworkName(networkType types.NetworkType) types.NetworkName {
 		return nn
 	}
 
-	// 2k and force networks do not have exact network names
+	// 2k network do not have exact network names
 	return ""
 }
 


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close https://github.com/filecoin-project/venus/issues/5543

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->

* forcenet 使用`testing` bundle 以支持创建32G矿工
* 在搭建forcenet网络时需要指定网络名 `./lotus-seed genesis new --network-name=forcenet localnet.json`，这样方便
venus 根据网络名来加载`testing` bundle


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
