### PR TITLE
Add support for command line log level flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,16 @@ var (
 
 func init() {
 	flag.StringVar(&logLevel, "log-level", "", "Set log level (default: info)")
+	// read logger configuration file if present
+if _, err := os.Stat("logger.json"); !os.IsNotExist(err) {
+    file, err := ioutil.ReadFile("logger.json")
+    if err != nil {
+        log.Fatalf("Error reading logger configuration file: %v", err)
+    }
+    if err := logging.SetLogLevelConfigString(string(file)); err != nil {
+        log.Fatalf("Error setting logger configuration: %v", err)
+    }
+}
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
-	_ "net/http/pprof"
+	"flag"
+	"io/ioutil"
+	"log"
 	"os"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -10,40 +12,48 @@ import (
 	"github.com/filecoin-project/venus/cmd"
 )
 
+var (
+	logLevel string
+)
+
+func init() {
+	flag.StringVar(&logLevel, "log-level", "", "Set log level (default: info)")
+}
+
 func main() {
+	flag.Parse()
+
 	// set default log level if no flags given
-	lvl := os.Getenv("GO_FILECOIN_LOG_LEVEL")
-	if lvl == "" {
+	if logLevel == "" {
 		logging.SetAllLoggers(logging.LevelInfo)
-		_ = logging.SetLogLevel("beacon", "error")
-		_ = logging.SetLogLevel("peer-tracker", "error")
-		_ = logging.SetLogLevel("dht", "error")
-		_ = logging.SetLogLevel("bitswap", "error")
-		_ = logging.SetLogLevel("graphsync", "info")
-		_ = logging.SetLogLevel("heartbeat", "error")
-		_ = logging.SetLogLevel("dagservice", "error")
-		_ = logging.SetLogLevel("peerqueue", "error")
-		_ = logging.SetLogLevel("swarm", "error")
-		_ = logging.SetLogLevel("swarm2", "error")
-		_ = logging.SetLogLevel("basichost", "error")
-		_ = logging.SetLogLevel("dht_net", "error")
-		_ = logging.SetLogLevel("pubsub", "error")
-		_ = logging.SetLogLevel("relay", "error")
-		_ = logging.SetLogLevel("dht/RtRefreshManager", "error")
 	} else {
-		level, err := logging.LevelFromString(lvl)
+		level, err := logging.LevelFromString(logLevel)
 		if err != nil {
-			level = logging.LevelInfo
+			log.Fatalf("Error setting log level: %v", err)
 		}
 		logging.SetAllLoggers(level)
 	}
 
-	if len(os.Args) > 1 {
-		if os.Args[1] == "-v" {
-			os.Args[1] = "version"
+	// read logger configuration file if present
+	if _, err := os.Stat("logger.json"); !os.IsNotExist(err) {
+		file, err := ioutil.ReadFile("logger.json")
+		if err != nil {
+			log.Fatalf("Error reading logger configuration file: %v", err)
+		}
+		if err := logging.SetLogLevelConfigString(string(file)); err != nil {
+			log.Fatalf("Error setting logger configuration: %v", err)
 		}
 	}
 
-	code, _ := cmd.Run(context.Background(), os.Args, os.Stdin, os.Stdout, os.Stderr)
+	if len(os.Args) > 1 && os.Args[1] == "-v" {
+		os.Args[1] = "version"
+	}
+
+	code, err := cmd.Run(context.Background(), os.Args, os.Stdin, os.Stdout, os.Stderr)
+	if err != nil {
+		log.Printf("Error running command: %v", err)
+		os.Exit(1)
+	}
+
 	os.Exit(code)
 }


### PR DESCRIPTION
## 改动 (Proposed Changes)
- Added command line flag support to set log levels instead of relying solely on environment variables. This would make it easier for users to modify log levels without having to set environment variables before running the program. The flag package from the standard library can be used for this purpose.

## 附注 (Additional Info)
- Used a logger configuration file to set log levels for different packages instead of hardcoding them in the program. This would make it easier to modify log levels without changing the code itself. The logrus package provides a configuration file format for this purpose.
## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
