### PR TITLE
chore: update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/baisc_checks.yml
+++ b/.github/workflows/baisc_checks.yml
@@ -13,10 +13,10 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
           cache: true

--- a/.github/workflows/common_build_upload.yml
+++ b/.github/workflows/common_build_upload.yml
@@ -29,7 +29,7 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
           fetch-depth: '0'
@@ -163,7 +163,7 @@ jobs:
             ./${{steps.vars.outputs.repo_name}}_${{steps.vars.outputs.tag}}_ubuntu.sha256
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ steps.vars.outputs.pub_method == 'pushRelease' }}
         with:
           name: ${{steps.vars.outputs.artifact_name}}
@@ -220,7 +220,7 @@ jobs:
   build-macos:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'true'
           fetch-depth: '0'

--- a/.github/workflows/common_go.yml
+++ b/.github/workflows/common_go.yml
@@ -17,10 +17,10 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
           cache: true
@@ -65,7 +65,7 @@ jobs:
         run: go test -coverpkg=./... -coverprofile=coverage_integration.txt -covermode=atomic -timeout=30m -parallel=4   -v $(go list ./... | grep -v /venus-shared/) -integration=true -unit=false
 
       - name: Upload
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token:
           files: ./coverage_unit.txt,./coverage_integration.txt,./coverage_venus_shared.txt


### PR DESCRIPTION
Updates GitHub Actions actions versions and configures dependabot to auto-update actions in the future. Related to https://filecoinproject.slack.com/archives/C03KLC57LKB/p1686680229440949