### PR TITLE
feat: support safe param for eth_getBlockByNumber for 30 blocks

### DIFF
--- a/app/submodule/eth/eth_utils.go
+++ b/app/submodule/eth/eth_utils.go
@@ -56,6 +56,22 @@ func getTipsetByBlockNumber(ctx context.Context, store *chain.Store, blkParam st
 			return nil, fmt.Errorf("cannot get parent tipset")
 		}
 		return parent, nil
+	case "safe":
+		latestHeight := head.Height() - 1
+		safeHeight := latestHeight - types.SafeEpochDelay
+		ts, err := store.GetTipSetByHeight(ctx, head, safeHeight, true)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get tipset at height: %v", safeHeight)
+		}
+		return ts, nil
+	case "finalized":
+		latestHeight := head.Height() - 1
+		safeHeight := latestHeight - constants.Finality
+		ts, err := store.GetTipSetByHeight(ctx, head, safeHeight, true)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get tipset at height: %v", safeHeight)
+		}
+		return ts, nil
 	default:
 		var num types.EthUint64
 		err := num.UnmarshalJSON([]byte(`"` + blkParam + `"`))

--- a/venus-shared/actors/types/eth.go
+++ b/venus-shared/actors/types/eth.go
@@ -25,6 +25,12 @@ import (
 
 var ErrInvalidAddress = errors.New("invalid Filecoin Eth address")
 
+// Research into Filecoin chain behaviour suggests that probabilistic finality
+// generally approaches the intended stability guarantee at, or near, 30 epochs.
+// Although a strictly "finalized" safe recommendation remains 900 epochs.
+// See https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0089.md
+const SafeEpochDelay = abi.ChainEpoch(30)
+
 // mainnet
 var Eip155ChainID = 314
 

--- a/venus-shared/types/eth.go
+++ b/venus-shared/types/eth.go
@@ -9,6 +9,7 @@ const (
 	EthAddressLength = types.EthAddressLength
 	EthBloomSize     = types.EthBloomSize
 	EthHashLength    = types.EthHashLength
+	SafeEpochDelay   = types.SafeEpochDelay
 )
 
 var (


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

pr: 12110

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
