### PR TITLE
fix: eth_getBlockReceipts should work similarly as geth

### DIFF
--- a/venus-shared/actors/types/eth.go
+++ b/venus-shared/actors/types/eth.go
@@ -1054,6 +1054,16 @@ func (e *EthBlockNumberOrHash) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
+	// check if input is a block hash (66 characters long)
+	if len(str) == 66 && strings.HasPrefix(str, "0x") {
+		hash, err := ParseEthHash(str)
+		if err != nil {
+			return err
+		}
+		e.BlockHash = &hash
+		return nil
+	}
+
 	return errors.New("invalid block param")
 }
 

--- a/venus-shared/actors/types/eth_test.go
+++ b/venus-shared/actors/types/eth_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -466,4 +467,105 @@ func BenchmarkEthHashFromCid(b *testing.B) {
 			b.Fatalf("Error in EthHashFromCid: %v", err)
 		}
 	}
+}
+
+func TestEthBlockNumberOrHashUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected func() EthBlockNumberOrHash
+		wantErr  bool
+	}{
+		{
+			name:  "Valid block number",
+			input: `{"blockNumber": "0x1234"}`,
+			expected: func() EthBlockNumberOrHash {
+				v := uint64(0x1234)
+				return EthBlockNumberOrHash{BlockNumber: (*EthUint64)(&v)}
+			},
+		},
+		{
+			name:  "Valid block hash",
+			input: `{"blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234"}`,
+			expected: func() EthBlockNumberOrHash {
+				h, _ := ParseEthHash("0x1234567890123456789012345678901234567890123456789012345678901234")
+				return EthBlockNumberOrHash{BlockHash: &h}
+			},
+		},
+		{
+			name:  "Valid block number as string",
+			input: `"0x1234"`,
+			expected: func() EthBlockNumberOrHash {
+				v := uint64(0x1234)
+				return EthBlockNumberOrHash{BlockNumber: (*EthUint64)(&v)}
+			},
+		},
+		{
+			name:  "Valid block hash as string",
+			input: `"0x1234567890123456789012345678901234567890123456789012345678901234"`,
+			expected: func() EthBlockNumberOrHash {
+				h, _ := ParseEthHash("0x1234567890123456789012345678901234567890123456789012345678901234")
+				return EthBlockNumberOrHash{BlockHash: &h}
+			},
+		},
+		{
+			name:  "Valid 'latest' string",
+			input: `"latest"`,
+			expected: func() EthBlockNumberOrHash {
+				return EthBlockNumberOrHash{PredefinedBlock: stringPtr("latest")}
+			},
+		},
+		{
+			name:  "Valid 'earliest' string",
+			input: `"earliest"`,
+			expected: func() EthBlockNumberOrHash {
+				return EthBlockNumberOrHash{PredefinedBlock: stringPtr("earliest")}
+			},
+		},
+		{
+			name:  "Valid 'pending' string",
+			input: `"pending"`,
+			expected: func() EthBlockNumberOrHash {
+				return EthBlockNumberOrHash{PredefinedBlock: stringPtr("pending")}
+			},
+		},
+		{
+			name:    "Invalid: both block number and hash",
+			input:   `{"blockNumber": "0x1234", "blockHash": "0x1234567890123456789012345678901234567890123456789012345678901234"}`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid block number",
+			input:   `{"blockNumber": "invalid"}`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid block hash",
+			input:   `{"blockHash": "invalid"}`,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid string",
+			input:   `"invalid"`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got EthBlockNumberOrHash
+			err := got.UnmarshalJSON([]byte(tc.input))
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err, fmt.Sprintf("did not expect error but got %s", err))
+				require.Equal(t, tc.expected(), got)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
