### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/venus-shared/types/tipset.go
+++ b/venus-shared/types/tipset.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -39,7 +40,7 @@ func NewTipSet(bhs []*BlockHeader) (*TipSet, error) {
 			return nil, fmt.Errorf("inconsistent block heights %d and %d", first.Height, blk.Height)
 		}
 
-		if !sortedCidArrsEqual(blk.Parents, first.Parents) {
+		if !slices.Equal(blk.Parents, first.Parents) {
 			return nil, fmt.Errorf("inconsistent block parents %s and %s", NewTipSetKey(first.Parents...), NewTipSetKey(blk.Parents...))
 		}
 
@@ -125,17 +126,7 @@ func (ts *TipSet) Equals(ots *TipSet) bool {
 		return false
 	}
 
-	if len(ts.cids) != len(ots.cids) {
-		return false
-	}
-
-	for i, cid := range ts.cids {
-		if cid != ots.cids[i] {
-			return false
-		}
-	}
-
-	return true
+	return slices.Equal(ts.cids, ots.cids)
 }
 
 // Len returns the number of blocks in the tipset.
@@ -256,20 +247,6 @@ func (ts *TipSet) ToSlice() []*BlockHeader {
 	slice := make([]*BlockHeader, len(ts.blocks))
 	copy(slice, ts.blocks)
 	return slice
-}
-
-func sortedCidArrsEqual(a, b []cid.Cid) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
 }
 
 func sortBlockHeadersInTipSet(blks []*blockHeaderWithCid) {


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).




## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
