### PR TITLE
Fix typos in code comments

### DIFF
--- a/pkg/chain/store.go
+++ b/pkg/chain/store.go
@@ -1457,7 +1457,7 @@ func (store *Store) LookupID(ctx context.Context, ts *types.TipSet, addr address
 }
 
 // ResolveToDeterministicAddress get key address of specify address.
-// if ths addr is bls/secpk address, return directly, other get the pubkey and generate address
+// if this addr is bls/secpk address, return directly, other get the pubkey and generate address
 func (store *Store) ResolveToDeterministicAddress(ctx context.Context, ts *types.TipSet, addr address.Address) (address.Address, error) {
 	st, err := store.StateView(ctx, ts)
 	if err != nil {

--- a/pkg/events/observer.go
+++ b/pkg/events/observer.go
@@ -155,7 +155,7 @@ func (o *observer) headChange(ctx context.Context, rev, app []*types.TipSet) err
 			// If we have more reverts, the next revert is the next head.
 			to = rev[i+1]
 		} else {
-			// At the end of the revert sequenece, we need to lookup the joint tipset
+			// At the end of the revert sequence, we need to lookup the joint tipset
 			// between the revert sequence and the apply sequence.
 			var err error
 			to, err = o.api.ChainGetTipSet(ctx, from.Parents())

--- a/pkg/messagepool/selection.go
+++ b/pkg/messagepool/selection.go
@@ -346,7 +346,7 @@ func (mp *MessagePool) selectMessagesOptimal(ctx context.Context, curTS, ts *typ
 		log.Infow("merge message chains done", "took", dt)
 	}
 
-	// 7. We have reached the edge of what can fit wholesale; if we still hae available
+	// 7. We have reached the edge of what can fit wholesale; if we still have available
 	//    gasLimit to pack some more chains, then trim the last chain and push it down.
 	//    Trimming invalidates subsequent dependent chains so that they can't be selected
 	//    as their dependency cannot be (fully) included.

--- a/pkg/net/exchange/client.go
+++ b/pkg/net/exchange/client.go
@@ -44,7 +44,7 @@ type client struct {
 var _ Client = (*client)(nil)
 
 // NewClient creates a new libp2p-based exchange.Client that uses the libp2p
-// ChainExhange protocol as the fetching mechanism.
+// ChainExchange protocol as the fetching mechanism.
 func NewClient(host host.Host, pmgr peermgr.IPeerMgr) Client {
 	return &client{
 		host:        host,


### PR DESCRIPTION
Corrected spelling errors in comments across 4 files:

- `store.go`: "ths addr" → "this addr"  
- `observer.go`: "sequenece" → "sequence"  
- `selection.go`: "hae available" → "have available"  
- `client.go`: "ChainExhange" → "ChainExchange"

These typos reduce code readability and professionalism. No functional changes.