### PR TITLE
chore: remove redundant variable declarations in for loops

### DIFF
--- a/venus-shared/actors/types/eth_test.go
+++ b/venus-shared/actors/types/eth_test.go
@@ -288,7 +288,6 @@ func TestEthFilterResultMarshalJSON(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			data, err := json.Marshal(tc.res)
 			require.NoError(t, err)
@@ -412,7 +411,6 @@ func TestEthAddressListUnmarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			var got EthAddressList
 			err := json.Unmarshal([]byte(tc.input), &got)

--- a/venus-shared/types/bigint_fil_test.go
+++ b/venus-shared/types/bigint_fil_test.go
@@ -184,7 +184,6 @@ func TestFilShort(t *testing.T) {
 		{fil: "-0.0002212344", expect: "-221.234 μFIL"},
 		{fil: "-0.00022123444", expect: "-221.234 μFIL"},
 	} {
-		s := s
 		t.Run(s.fil, func(t *testing.T) {
 			f, err := ParseFIL(s.fil)
 			require.NoError(t, err)

--- a/venus-shared/types/percent_test.go
+++ b/venus-shared/types/percent_test.go
@@ -20,7 +20,6 @@ func TestPercent(t *testing.T) {
 		{-1012, "-10.12"},
 		{0, "0.0"},
 	} {
-		tc := tc
 		t.Run(fmt.Sprintf("%d <> %s", tc.p, tc.s), func(t *testing.T) {
 			m, err := tc.p.MarshalJSON()
 			require.NoError(t, err)


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->

The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore



## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
