### PR TITLE
Polish Doc Comments

### DIFF
--- a/pkg/chain/message_store.go
+++ b/pkg/chain/message_store.go
@@ -473,7 +473,7 @@ func (ms *MessageStore) LoadTipSetMessage(ctx context.Context, ts *types.TipSet)
 	return blockMsg, nil
 }
 
-// MessagesForTipset return of message ( bls message + secp message) of tipset
+// MessagesForTipset returns messages (BLS + secp) for a tipset.
 func (ms *MessageStore) MessagesForTipset(ts *types.TipSet) ([]types.ChainMsg, error) {
 	bmsgs, err := ms.LoadTipSetMessage(context.TODO(), ts)
 	if err != nil {

--- a/pkg/chain/store.go
+++ b/pkg/chain/store.go
@@ -1338,7 +1338,7 @@ func (store *Store) PutMessage(ctx context.Context, m storable) (cid.Cid, error)
 	return PutMessage(ctx, store.bsstore, m)
 }
 
-// Blockstore return local blockstore
+// Blockstore returns local blockstore.
 // todo remove this method, and code that need blockstore should get from blockstore submodule
 func (store *Store) Blockstore() blockstoreutil.Blockstore { // nolint
 	return store.bsstore
@@ -1467,7 +1467,7 @@ func (store *Store) ResolveToDeterministicAddress(ctx context.Context, ts *types
 	return st.ResolveToDeterministicAddress(ctx, addr)
 }
 
-// StateView return state view at ts epoch
+// StateView returns state view at ts epoch.
 func (store *Store) StateView(ctx context.Context, ts *types.TipSet) (*state.View, error) {
 	if ts == nil {
 		ts = store.head
@@ -1480,7 +1480,7 @@ func (store *Store) StateView(ctx context.Context, ts *types.TipSet) (*state.Vie
 	return state.NewView(store.stateAndBlockSource, root), nil
 }
 
-// AccountView return account view at ts state
+// AccountView returns account view at ts state.
 func (store *Store) AccountView(ctx context.Context, ts *types.TipSet) (state.AccountView, error) {
 	if ts == nil {
 		ts = store.head

--- a/pkg/chainsync/types/target_tracker.go
+++ b/pkg/chainsync/types/target_tracker.go
@@ -60,7 +60,7 @@ func (target *Target) HasChild(t *Target) bool {
 	return target.Head.Key().ContainsAll(t.Head.Key())
 }
 
-// Key return identity of target . key=weight+height+parent
+// Key returns the identity of a target. key=weight+height+parent.
 func (target *Target) Key() string {
 	weightIn := target.Head.ParentWeight()
 	return weightIn.String() +
@@ -395,7 +395,7 @@ func (tq *TargetTracker) Remove(t *Target) {
 	tq.history.PushBack(t)
 }
 
-// History return sync history
+// History returns sync history.
 func (tq *TargetTracker) History() []*Target {
 	tq.lk.Lock()
 	defer tq.lk.Unlock()

--- a/pkg/genesis/genesis.go
+++ b/pkg/genesis/genesis.go
@@ -46,7 +46,7 @@ var Ticket = types.Ticket{
 	},
 }
 
-// MakeGenesis return a func to construct a genesis block
+// MakeGenesis returns a function to construct a genesis block.
 func MakeGenesis(ctx context.Context, rep repo.Repo, outFile, genesisTemplate string, para *config.ForkUpgradeConfig) InitFunc {
 	return func(_ cbor.IpldStore, bs blockstoreutil.Blockstore) (*types.BlockHeader, error) {
 		glog.Warn("Generating new random genesis block, note that this SHOULD NOT happen unless you are setting up new network")

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -243,7 +243,7 @@ func (w *Wallet) WalletSign(ctx context.Context, addr address.Address, msg []byt
 	return ki.SignBytes(ctx, msg, addr)
 }
 
-// DSBacked return the first wallet backend
+// DSBacked returns the first wallet backend.
 // todo support multi wallet backend
 func (w *Wallet) DSBacked() (*DSBackend, error) {
 	backends := w.Backends(DSBackendType)
@@ -283,7 +283,7 @@ func (w *Wallet) SetPassword(ctx context.Context, password []byte) error {
 	return backend.SetPassword(ctx, password)
 }
 
-// HasPassword return whether the password has been set in the wallet
+// HasPassword returns whether the password has been set in the wallet.
 func (w *Wallet) HasPassword(ctx context.Context) bool {
 	backend, err := w.DSBacked()
 	if err != nil {
@@ -293,7 +293,7 @@ func (w *Wallet) HasPassword(ctx context.Context) bool {
 	return backend.HasPassword()
 }
 
-// WalletState return wallet state(lock/unlock)
+// WalletState returns wallet state (lock/unlock).
 func (w *Wallet) WalletState(ctx context.Context) int {
 	backend, err := w.DSBacked()
 	if err != nil {


### PR DESCRIPTION
  This PR refines 10 exported Go doc comments across `chainsync`, `genesis`, `wallet`, and `chain` packages.

  It fixes clear grammar/wording issues (for example, `return` -> `returns`, and `return of message` -> `returns messages`) to make  API docs clearer and consistent with Go comment conventions.

  Safety is straightforward: these are comment-only edits with zero behavioral, signature, or logic changes.