### PR TITLE
fix: resolve daemon failed to import snapshot

### DIFF
--- a/pkg/chain/store.go
+++ b/pkg/chain/store.go
@@ -1046,11 +1046,6 @@ func (store *Store) Import(ctx context.Context, network string, f3Ds datastore.D
 					return nil, nil, fmt.Errorf("F3Data CID mismatch")
 				}
 
-				f3r := bufio.NewReader(f3Reader)
-
-				prefix := F3DatastorePrefix(network)
-				f3DsWrapper := namespace.Wrap(f3Ds, prefix)
-
 				cfg, err := networks.GetNetworkConfigFromName(network)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to get network config: %w, network: %s", err, network)
@@ -1060,6 +1055,10 @@ func (store *Store) Import(ctx context.Context, network string, f3Ds datastore.D
 					log.Warnf("Snapshot contains F3 data but F3 manifest is not available in this build. Skipping F3 data import.")
 					// Skip F3 import but continue with chain import
 				} else {
+					f3r := bufio.NewReader(f3Reader)
+					prefix := F3DatastorePrefix(string(f3Manifest.NetworkName))
+					f3DsWrapper := namespace.Wrap(f3Ds, prefix)
+
 					log.Info("Importing F3Data to datastore")
 					if err := certstore.ImportSnapshotToDatastore(ctx, f3r, f3DsWrapper, f3Manifest); err != nil {
 						return nil, nil, fmt.Errorf("failed to import f3Data to datastore: %w", err)
@@ -1128,7 +1127,7 @@ func (store *Store) Import(ctx context.Context, network string, f3Ds datastore.D
 		return nil, nil, fmt.Errorf("expected genesis block to have height 0 (genesis), got %d: %s", tailBlock.Height, tailBlock.Cid())
 	}
 
-	root, err := store.GetTipSet(ctx, types.NewTipSetKey(br.Roots...))
+	root, err := store.GetTipSet(ctx, types.NewTipSetKey(roots...))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load root tipset from chainfile: %w", err)
 	}


### PR DESCRIPTION
- Fix F3 datastore prefix to use f3Manifest.NetworkName instead of the raw network parameter
- Fix roots variable to use the updated roots value instead of br.Roots
- Move F3 data import code inside the f3Manifest != nil block to ensure it's only executed when F3 manifest is available

## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

Fixes: daemon failed to import snapshot

## 改动 (Proposed Changes)

This PR fixes two issues that cause "daemon failed to import snapshot" error:

### Fix 1: F3 Datastore Prefix uses wrong network parameter

**Problem:** The original code uses the `network` parameter passed to the Import function, but it should use `f3Manifest.NetworkName` which is derived from the network config.

**Before:**
```go
prefix := F3DatastorePrefix(network)
f3DsWrapper := namespace.Wrap(f3Ds, prefix)
```

**After:**
```go
prefix := F3DatastorePrefix(string(f3Manifest.NetworkName))
f3DsWrapper := namespace.Wrap(f3Ds, prefix)
```

Additionally, these lines were moved inside the `else` block where `f3Manifest != nil`, so they're only executed when F3 manifest is available.

### Fix 2: Use correct roots variable

**Problem:** The original code uses `br.Roots` (the initial value), but the `roots` variable may be reassigned to `metadata.HeadTipsetKey` in the V0 format case.

**Before:**
```go
root, err := store.GetTipSet(ctx, types.NewTipSetKey(br.Roots...))
```

**After:**
```go
root, err := store.GetTipSet(ctx, types.NewTipSetKey(roots...))
```

<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 存在兼容性问题（接口, 配置，数据，灰度），如果存在需要进行文档说明 / This PR has compatibility issues (API, Configuration, Data, GrayRelease), if so, need to be documented.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
