### PR TITLE
feat: `eth_baseFee`

### DIFF
--- a/app/submodule/eth/dummy.go
+++ b/app/submodule/eth/dummy.go
@@ -133,6 +133,10 @@ func (e *ethAPIDummy) EthGasPrice(ctx context.Context) (types.EthBigInt, error) 
 	return types.EthBigIntZero, ErrModuleDisabled
 }
 
+func (e *ethAPIDummy) EthBaseFee(ctx context.Context) (types.EthBigInt, error) {
+	return types.EthBigIntZero, ErrModuleDisabled
+}
+
 func (e *ethAPIDummy) EthEstimateGas(ctx context.Context, p jsonrpc.RawParams) (types.EthUint64, error) {
 	return 0, ErrModuleDisabled
 }

--- a/app/submodule/eth/eth_api.go
+++ b/app/submodule/eth/eth_api.go
@@ -966,6 +966,18 @@ func (a *ethAPI) EthGasPrice(ctx context.Context) (types.EthBigInt, error) {
 	return types.EthBigInt(gasPrice), nil
 }
 
+func (a *ethAPI) EthBaseFee(ctx context.Context) (types.EthBigInt, error) {
+	ts, err := a.chain.ChainHead(ctx)
+	if err != nil {
+		return types.EthBigInt(big.Zero()), err
+	}
+	nextBaseFee, err := a.em.chainModule.MessageStore.ComputeBaseFee(ctx, ts, a.em.cfg.NetworkParams.ForkUpgradeParam)
+	if err != nil {
+		return types.EthBigInt(big.Zero()), fmt.Errorf("computing next base fee: %w", err)
+	}
+	return types.EthBigInt(nextBaseFee), nil
+}
+
 func (a *ethAPI) EthSendRawTransaction(ctx context.Context, rawTx types.EthBytes) (types.EthHash, error) {
 	txArgs, err := types.ParseEthTransaction(rawTx)
 	if err != nil {

--- a/app/submodule/eth/eth_test.go
+++ b/app/submodule/eth/eth_test.go
@@ -2,18 +2,29 @@ package eth
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 	cbg "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	chainmod "github.com/filecoin-project/venus/app/submodule/chain"
+	pkgchain "github.com/filecoin-project/venus/pkg/chain"
+	"github.com/filecoin-project/venus/pkg/config"
+	"github.com/filecoin-project/venus/pkg/constants"
 	"github.com/filecoin-project/venus/pkg/messagepool"
+	"github.com/filecoin-project/venus/pkg/testhelpers"
+	"github.com/filecoin-project/venus/venus-shared/api/chain/v1/mock"
+	blockstoreutil "github.com/filecoin-project/venus/venus-shared/blockstore"
 	"github.com/filecoin-project/venus/venus-shared/types"
 )
 
@@ -291,4 +302,42 @@ func TestDecodePayload(t *testing.T) {
 	// random codec should fail
 	_, err = decodePayload(w.Bytes(), 42)
 	require.Error(t, err)
+}
+
+func TestEthBaseFee(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Place the tipset in the Breeze tamping window so ComputeBaseFee returns
+	// a flat 100 without needing stored block messages.
+	forkParams := &config.ForkUpgradeConfig{
+		UpgradeBreezeHeight:      0,
+		BreezeGasTampingDuration: 200,
+	}
+	ts := testhelpers.RequireTipsetWithHeight(t, 50)
+
+	mockNode := mock.NewMockFullNode(ctrl)
+	mockNode.EXPECT().ChainHead(gomock.Any()).Return(ts, nil)
+
+	bs := blockstoreutil.Adapt(blockstore.NewBlockstore(datastore.NewMapDatastore()))
+	ms := pkgchain.NewMessageStore(bs, forkParams)
+
+	a := &ethAPI{
+		chain: mockNode,
+		em: &EthSubModule{
+			cfg: &config.Config{
+				NetworkParams: &config.NetworkParamsConfig{
+					ForkUpgradeParam: forkParams,
+				},
+			},
+			chainModule: &chainmod.ChainSubmodule{
+				MessageStore: ms,
+			},
+		},
+	}
+
+	result, err := a.EthBaseFee(ctx)
+	require.NoError(t, err)
+	require.Equal(t, types.EthBigInt(big.NewInt(constants.MinimumBaseFee)), result)
 }

--- a/venus-shared/api/chain/v1/eth.go
+++ b/venus-shared/api/chain/v1/eth.go
@@ -54,6 +54,7 @@ type IETH interface {
 	NetListening(ctx context.Context) (bool, error)                                                                                                      //perm:read
 	EthProtocolVersion(ctx context.Context) (types.EthUint64, error)                                                                                     //perm:read
 	EthGasPrice(ctx context.Context) (types.EthBigInt, error)                                                                                            //perm:read
+	EthBaseFee(ctx context.Context) (types.EthBigInt, error)                                                                                             //perm:read
 	EthFeeHistory(ctx context.Context, p jsonrpc.RawParams) (types.EthFeeHistory, error)                                                                 //perm:read
 
 	EthMaxPriorityFeePerGas(ctx context.Context) (types.EthBigInt, error)                                       //perm:read

--- a/venus-shared/api/chain/v1/method.md
+++ b/venus-shared/api/chain/v1/method.md
@@ -72,6 +72,7 @@ curl http://<ip>:<port>/rpc/v1 -X POST -H "Content-Type: application/json"  -H "
 * [ETH](#eth)
   * [EthAccounts](#ethaccounts)
   * [EthAddressToFilecoinAddress](#ethaddresstofilecoinaddress)
+  * [EthBaseFee](#ethbasefee)
   * [EthBlockNumber](#ethblocknumber)
   * [EthCall](#ethcall)
   * [EthChainId](#ethchainid)
@@ -2549,6 +2550,15 @@ Inputs:
 ```
 
 Response: `"f01234"`
+
+### EthBaseFee
+
+
+Perms: read
+
+Inputs: `[]`
+
+Response: `"0x0"`
 
 ### EthBlockNumber
 EthBlockNumber returns the height of the latest (heaviest) TipSet

--- a/venus-shared/api/chain/v1/mock/mock_fullnode.go
+++ b/venus-shared/api/chain/v1/mock/mock_fullnode.go
@@ -489,6 +489,21 @@ func (mr *MockFullNodeMockRecorder) EthAddressToFilecoinAddress(arg0, arg1 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthAddressToFilecoinAddress", reflect.TypeOf((*MockFullNode)(nil).EthAddressToFilecoinAddress), arg0, arg1)
 }
 
+// EthBaseFee mocks base method.
+func (m *MockFullNode) EthBaseFee(arg0 context.Context) (types.EthBigInt, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EthBaseFee", arg0)
+	ret0, _ := ret[0].(types.EthBigInt)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EthBaseFee indicates an expected call of EthBaseFee.
+func (mr *MockFullNodeMockRecorder) EthBaseFee(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EthBaseFee", reflect.TypeOf((*MockFullNode)(nil).EthBaseFee), arg0)
+}
+
 // EthBlockNumber mocks base method.
 func (m *MockFullNode) EthBlockNumber(arg0 context.Context) (types.EthUint64, error) {
 	m.ctrl.T.Helper()

--- a/venus-shared/api/chain/v1/proxy_gen.go
+++ b/venus-shared/api/chain/v1/proxy_gen.go
@@ -884,6 +884,7 @@ type IETHStruct struct {
 	Internal struct {
 		EthAccounts                            func(ctx context.Context) ([]types.EthAddress, error)                                                                                     `perm:"read"`
 		EthAddressToFilecoinAddress            func(ctx context.Context, ethAddress types.EthAddress) (address.Address, error)                                                           `perm:"read"`
+		EthBaseFee                             func(ctx context.Context) (types.EthBigInt, error)                                                                                        `perm:"read"`
 		EthBlockNumber                         func(ctx context.Context) (types.EthUint64, error)                                                                                        `perm:"read"`
 		EthCall                                func(ctx context.Context, tx types.EthCall, blkParam types.EthBlockNumberOrHash) (types.EthBytes, error)                                  `perm:"read"`
 		EthChainId                             func(ctx context.Context) (types.EthUint64, error)                                                                                        `perm:"read"`
@@ -928,6 +929,9 @@ func (s *IETHStruct) EthAccounts(p0 context.Context) ([]types.EthAddress, error)
 }
 func (s *IETHStruct) EthAddressToFilecoinAddress(p0 context.Context, p1 types.EthAddress) (address.Address, error) {
 	return s.Internal.EthAddressToFilecoinAddress(p0, p1)
+}
+func (s *IETHStruct) EthBaseFee(p0 context.Context) (types.EthBigInt, error) {
+	return s.Internal.EthBaseFee(p0)
 }
 func (s *IETHStruct) EthBlockNumber(p0 context.Context) (types.EthUint64, error) {
 	return s.Internal.EthBlockNumber(p0)

--- a/venus-shared/compatible-checks/api-diff.txt
+++ b/venus-shared/compatible-checks/api-diff.txt
@@ -107,6 +107,7 @@ github.com/filecoin-project/venus/venus-shared/api/chain/v1.FullNode <> github.c
 	+ Concurrent
 	- CreateBackup
 	- Discover
+	+ EthBaseFee
 	> EthGetBlockTransactionCountByNumber {[func(context.Context, types.EthUint64) (types.EthUint64, error) <> func(context.Context, string) (ethtypes.EthUint64, error)] base=func in type: #1 input; nested={[types.EthUint64 <> string] base=type kinds: uint64 != string; nested=nil}}
 	> EthGetTransactionByBlockHashAndIndex {[func(context.Context, types.EthHash, types.EthUint64) (types.EthTx, error) <> func(context.Context, ethtypes.EthHash, ethtypes.EthUint64) (*ethtypes.EthTx, error)] base=func out type: #0 input; nested={[types.EthTx <> *ethtypes.EthTx] base=type kinds: struct != ptr; nested=nil}}
 	> EthGetTransactionByBlockNumberAndIndex {[func(context.Context, types.EthUint64, types.EthUint64) (types.EthTx, error) <> func(context.Context, string, ethtypes.EthUint64) (*ethtypes.EthTx, error)] base=func in type: #1 input; nested={[types.EthUint64 <> string] base=type kinds: uint64 != string; nested=nil}}

--- a/venus-shared/compatible-checks/api-perm.txt
+++ b/venus-shared/compatible-checks/api-perm.txt
@@ -68,6 +68,7 @@ v1: github.com/filecoin-project/venus/venus-shared/api/chain/v1 <> github.com/fi
 	- IMinerState.StateMinerSectorSize
 	- IMinerState.StateMinerWorkerAddress
 	- EthSubscriber.EthSubscription
+	- IETH.EthBaseFee
 	- IMessagePool.GasBatchEstimateMessageGas
 	- IMessagePool.MpoolDeleteByAdress
 	- IMessagePool.MpoolPublishByAddr


### PR DESCRIPTION

Adds the nonstandard `eth_baseFee` eth jsonrpc method.
This method returns the calculated base fee of the next epoch.
See https://github.com/filecoin-project/lotus/pull/13615
#### Changes
* add `eth_baseFee`
* doc gen