### PR TITLE
feat(mempool): raise MaxUntrustedActorPendingMessages 10→100

### DIFF
--- a/pkg/messagepool/messagepool.go
+++ b/pkg/messagepool/messagepool.go
@@ -68,8 +68,14 @@ var (
 )
 
 var (
-	MaxActorPendingMessages          = 1000
-	MaxUntrustedActorPendingMessages = 10
+	MaxActorPendingMessages = 1000
+	// MaxUntrustedActorPendingMessages is the maximum number of pending messages
+	// per actor for untrusted (non-local) messages. Raised from 10 to 100 because
+	// the previous limit was too tight — users could easily hit
+	// ErrTooManyPendingMessages when basefee spikes or block production is delayed.
+	// 100 is still well below the trusted path limit of 1000, and untrusted messages
+	// keep maxNonceGap = 0, so spam/DoS protection is not compromised.
+	MaxUntrustedActorPendingMessages = 100
 )
 
 var MaxNonceGap = uint64(4)


### PR DESCRIPTION
## 变更说明

提高 untrusted 消息推送上限。ref  [#13636](https://github.com/filecoin-project/lotus/pull/13636)

### 背景

当 basefee 飙升或区块打包延迟时，untrusted 消息的 pending 上限 (10) 过紧，容易导致用户收到 `ErrTooManyPendingMessages` 错误。

### 修改

| 文件 | 修改前 | 修改后 |
|------|:------:|:------:|
| `pkg/messagepool/messagepool.go` | `MaxUntrustedActorPendingMessages = 10` | `= 100` |

### 安全评估

- 100 仍远低于信任路径上限 1000
- `maxNonceGap = 0` 规则不变，spam/DoS 防护不受影响

### 审查状态

- [x] 代码审查通过（reviewer 确认格式、逻辑、安全均无问题）
- [x] `go vet` 通过
- [x] `gofmt` 格式检查通过