### PR TITLE
fix(gas): add nblocksincl upper limit of 128 for GasEstimateGasPremium

### DIFF
--- a/pkg/messagepool/gas.go
+++ b/pkg/messagepool/gas.go
@@ -96,7 +96,7 @@ func (mp *MessagePool) GasEstimateFeeCap(
 	return out, nil
 }
 
-// finds 55th percntile instead of median to put negative pressure on gas price
+// finds ~52.5th percentile instead of median to put negative pressure on gas price
 func medianGasPremium(prices []GasMeta, blocks int) abi.TokenAmount {
 	sort.Slice(prices, func(i, j int) bool {
 		// sort desc by price
@@ -132,6 +132,9 @@ func (mp *MessagePool) GasEstimateGasPremium(
 ) (big.Int, error) {
 	if nblocksincl == 0 {
 		nblocksincl = 1
+	}
+	if nblocksincl > 128 {
+		nblocksincl = 128
 	}
 
 	var prices []GasMeta


### PR DESCRIPTION
## Summary

Add an upper limit of 128 for `nblocksincl` parameter in `GasEstimateGasPremium` to prevent excessive block traversal. Also fix the `medianGasPremium` comment from `55th percntile` to `~52.5th percentile`.

Ref: [lotus#13556](https://github.com/filecoin-project/lotus/pull/13556)

## Changes

### 1. `pkg/messagepool/gas.go` — nblocksincl cap

```go
if nblocksincl > 128 {
    nblocksincl = 128
}
```

### 2. `pkg/messagepool/gas.go` — comment fix

`medianGasPremium` comment corrected from `55th percntile` to `~52.5th percentile`.

## Checklist

- [x] gofmt passes
- [x] go build ./pkg/messagepool/... passes
- [x] go vet ./pkg/messagepool/... passes
- [x] Reviewer approved