### PR TITLE
fix(eth): multipart ETH API fixes — null epoch, topics limit, nonce validation, replaced tx, by-index post-state

### DIFF
--- a/app/submodule/eth/eth_api.go
+++ b/app/submodule/eth/eth_api.go
@@ -306,8 +306,8 @@ func (a *ethAPI) EthGetTransactionByHashLimited(ctx context.Context, txHash *typ
 		c = txHash.ToCid()
 	}
 
-	// first, try to get the cid from mined transactions
-	msgLookup, err := a.chain.StateSearchMsg(ctx, types.EmptyTSK, c, limit, true)
+	// first, try to get the cid from mined transactions (allowReplaced=false so replaced tx hashes return nil)
+	msgLookup, err := a.chain.StateSearchMsg(ctx, types.EmptyTSK, c, limit, false)
 	if err == nil && msgLookup != nil {
 		tx, err := newEthTxFromMessageLookup(ctx, msgLookup, -1, a.em.chainModule.MessageStore, a.em.chainModule.ChainReader)
 		if err == nil {
@@ -464,15 +464,15 @@ func (a *ethAPI) EthGetTransactionReceiptLimited(ctx context.Context, txHash typ
 		c = txHash.ToCid()
 	}
 
-	msgLookup, err := a.chain.StateSearchMsg(ctx, types.EmptyTSK, c, limit, true)
+	msgLookup, err := a.chain.StateSearchMsg(ctx, types.EmptyTSK, c, limit, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup Eth Txn %s as %s: %w", txHash, c, err)
 	}
 	if msgLookup == nil {
-		// This is the best we can do. We may just not have indexed this transaction, or we may have a
-		// limit applied and not searched far back enough, but we don't have a way to go. Because
-		// Ethereum tooling expects an empty response for transaction-not-found, we don't have a way of
-		// differentiating between "can't find" and "doesn't exist".
+		// This is the best we can do. We may just not have indexed this transaction, we may have a
+		// limit applied and not searched far back enough, or the transaction was replaced.
+		// Ethereum tooling expects an empty response for transaction-not-found, so all three cases
+		// are handled the same way.
 		return nil, nil
 	}
 
@@ -503,7 +503,44 @@ func (a *ethAPI) EthGetTransactionReceiptLimited(ctx context.Context, txHash typ
 }
 
 func (a *ethAPI) EthGetTransactionByBlockHashAndIndex(ctx context.Context, blkHash types.EthHash, txIndex types.EthUint64) (types.EthTx, error) {
-	return types.EthTx{}, ErrUnsupported
+	// Build a block number-or-hash param from the hash to reuse the strict resolver
+	blockParam := types.EthBlockNumberOrHash{
+		BlockHash:        &blkHash,
+		RequireCanonical: true,
+	}
+	ts, err := getTipsetByEthBlockNumberOrHashStrict(ctx, a.em.chainModule.ChainReader, blockParam)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to get tipset: %w", err)
+	}
+
+	msgs, err := a.em.chainModule.MessageStore.MessagesForTipset(ts)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to load messages for tipset: %w", err)
+	}
+
+	if int(txIndex) >= len(msgs) {
+		return types.EthTx{}, fmt.Errorf("transaction index %d out of range (tipset has %d messages)", txIndex, len(msgs))
+	}
+
+	msg := msgs[txIndex]
+
+	// Load post-state for correct address resolution
+	state, err := a.em.chainModule.ChainReader.GetTipSetState(ctx, ts)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to get tipset state: %w", err)
+	}
+
+	tsCid, err := ts.Key().Cid()
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to get tipset key cid: %w", err)
+	}
+
+	tx, err := newEthTx(ctx, state, ts.Height(), tsCid, msg.Cid(), int(txIndex), a.em.chainModule.MessageStore)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to create EthTx: %w", err)
+	}
+
+	return tx, nil
 }
 
 func (a *ethAPI) EthGetBlockReceipts(ctx context.Context, blockParam types.EthBlockNumberOrHash) ([]*types.EthTxReceipt, error) {
@@ -511,7 +548,7 @@ func (a *ethAPI) EthGetBlockReceipts(ctx context.Context, blockParam types.EthBl
 }
 
 func (a *ethAPI) EthGetBlockReceiptsLimited(ctx context.Context, blockParam types.EthBlockNumberOrHash, limit abi.ChainEpoch) ([]*types.EthTxReceipt, error) {
-	ts, err := getTipsetByEthBlockNumberOrHash(ctx, a.em.chainModule.ChainReader, blockParam)
+	ts, err := getTipsetByEthBlockNumberOrHashStrict(ctx, a.em.chainModule.ChainReader, blockParam)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tipset: %w", err)
 	}
@@ -572,7 +609,42 @@ func (a *ethAPI) EthGetBlockReceiptsLimited(ctx context.Context, blockParam type
 }
 
 func (a *ethAPI) EthGetTransactionByBlockNumberAndIndex(ctx context.Context, blkNum types.EthUint64, txIndex types.EthUint64) (types.EthTx, error) {
-	return types.EthTx{}, ErrUnsupported
+	blockParam := types.EthBlockNumberOrHash{
+		BlockNumber: (*types.EthUint64)(&blkNum),
+	}
+	ts, err := getTipsetByEthBlockNumberOrHashStrict(ctx, a.em.chainModule.ChainReader, blockParam)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to get tipset: %w", err)
+	}
+
+	msgs, err := a.em.chainModule.MessageStore.MessagesForTipset(ts)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to load messages for tipset: %w", err)
+	}
+
+	if int(txIndex) >= len(msgs) {
+		return types.EthTx{}, fmt.Errorf("transaction index %d out of range (tipset has %d messages)", txIndex, len(msgs))
+	}
+
+	msg := msgs[txIndex]
+
+	// Load post-state for correct address resolution
+	state, err := a.em.chainModule.ChainReader.GetTipSetState(ctx, ts)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to get tipset state: %w", err)
+	}
+
+	tsCid, err := ts.Key().Cid()
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to get tipset key cid: %w", err)
+	}
+
+	tx, err := newEthTx(ctx, state, ts.Height(), tsCid, msg.Cid(), int(txIndex), a.em.chainModule.MessageStore)
+	if err != nil {
+		return types.EthTx{}, fmt.Errorf("failed to create EthTx: %w", err)
+	}
+
+	return tx, nil
 }
 
 // EthGetCode returns string value of the compiled bytecode

--- a/app/submodule/eth/eth_utils.go
+++ b/app/submodule/eth/eth_utils.go
@@ -147,6 +147,28 @@ func getTipsetByEthBlockNumberOrHash(ctx context.Context, store *chain.Store, bl
 	return nil, errors.New("invalid block param")
 }
 
+// getTipsetByEthBlockNumberOrHashStrict is like getTipsetByEthBlockNumberOrHash but rejects
+// explicit numeric null epochs with ErrNullRound. This is used by concrete block/execution
+// APIs (e.g., eth_getBlockReceipts) where resolving a null epoch to the previous non-null
+// tipset would be misleading. State-at-epoch APIs (eth_call, eth_estimateGas, balance, etc.)
+// should continue to use the non-strict version.
+func getTipsetByEthBlockNumberOrHashStrict(ctx context.Context, store *chain.Store, blkParam types.EthBlockNumberOrHash) (*types.TipSet, error) {
+	// Only apply strict checking for numeric block numbers. Predefined blocks
+	// ("latest", "pending") and block-hash lookups are inherently concrete.
+	if blkParam.BlockNumber != nil {
+		height := abi.ChainEpoch(*blkParam.BlockNumber)
+		ts, err := getTipsetByEthBlockNumberOrHash(ctx, store, blkParam)
+		if err != nil {
+			return nil, err
+		}
+		if ts.Height() != height {
+			return nil, ErrNullRound
+		}
+		return ts, nil
+	}
+	return getTipsetByEthBlockNumberOrHash(ctx, store, blkParam)
+}
+
 func newEthBlockFromFilecoinTipSet(ctx context.Context, ts *types.TipSet, fullTxInfo bool, ms *chain.MessageStore, stmgr *statemanger.Stmgr) (types.EthBlock, error) {
 	parentKeyCid, err := ts.Parents().Cid()
 	if err != nil {
@@ -461,6 +483,9 @@ func newEthTxFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, s
 }
 
 func parseEthTopics(topics types.EthTopicSpec) (map[string][][]byte, error) {
+	if len(topics) > 4 {
+		return nil, fmt.Errorf("log filter cannot have more than 4 topics, got %d", len(topics))
+	}
 	keys := map[string][][]byte{}
 	for idx, vals := range topics {
 		if len(vals) == 0 {

--- a/venus-shared/actors/types/eth.go
+++ b/venus-shared/actors/types/eth.go
@@ -375,16 +375,11 @@ func (n *EthNonce) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s = strings.Replace(s, "0x", "", -1)
-	if len(s)%2 == 1 {
-		s = "0" + s
-	}
-
-	decoded, err := hex.DecodeString(s)
+	decoded, err := decodeHexString(s, len(n))
 	if err != nil {
 		return err
 	}
-	copy(n[:], decoded[:8])
+	copy(n[:], decoded)
 	return nil
 }
 


### PR DESCRIPTION
## 改动清单 (5 项修复)

### 1. Null epoch 拒绝 (#13694)
block execution API（`eth_getBlockReceipts`）遇到 null epoch 时返回 `ErrNullRound` 而非静默解析到前一个非空 tipset。
- 新增 `getTipsetByEthBlockNumberOrHashStrict` 函数
- `EthGetBlockReceiptsLimited` 改用 strict 版本

### 2. Log filter topics 限制 (#13676)
`parseEthTopics` 中增加 `len(topics) > 4` 检查，拒绝超过 4 个 topic 的 filter。

### 3. EthNonce 长度验证 (#13696)
修复 `EthNonce.UnmarshalJSON`：使用 `decodeHexString` 验证精确 8 字节长度，防止短输入 panic 和长输入静默截断。

### 4. Replaced tx 返回 null (#13664)
`EthGetTransactionByHash` 和 `EthGetTransactionReceiptLimited` 的 `StateSearchMsg` 调用中 `allowReplaced=false`，被替换的交易返回 null。

### 5. By-index 交易查询 post-state 解析 (#13699)
`EthGetTransactionByBlockHashAndIndex` 和 `EthGetTransactionByBlockNumberAndIndex` 从 `ErrUnsupported` 改为完整实现，使用 post-state 解析地址。

### 改动文件
| 文件 | 改动 |
|------|------|
| `app/submodule/eth/eth_api.go` | +92/-17：实现 2 个 by-index 查询，replaced tx 修复，null epoch strict 调用 |
| `app/submodule/eth/eth_utils.go` | +25：新增 `getTipsetByEthBlockNumberOrHashStrict`，`parseEthTopics` 增加 limit |
| `venus-shared/actors/types/eth.go` | +4/-8：`EthNonce.UnmarshalJSON` 改用 `decodeHexString` |

Ref: #13694, #13676, #13696, #13664, #13699