### PR TITLE
fix(eth-nonce): validate exact 8-byte length in UnmarshalJSON

### DIFF
--- a/venus-shared/actors/types/eth.go
+++ b/venus-shared/actors/types/eth.go
@@ -375,16 +375,11 @@ func (n *EthNonce) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	s = strings.Replace(s, "0x", "", -1)
-	if len(s)%2 == 1 {
-		s = "0" + s
-	}
-
-	decoded, err := hex.DecodeString(s)
+	decoded, err := decodeHexString(s, 8)
 	if err != nil {
 		return err
 	}
-	copy(n[:], decoded[:8])
+	copy(n[:], decoded)
 	return nil
 }
 


### PR DESCRIPTION
修复 EthNonce.UnmarshalJSON 中短输入导致 panic 的问题。

原实现直接对 decoded[:8] 取值，当 hex 输入不足 8 字节时触发 index out of range panic；
同时长输入被静默截断。改为使用 decodeHexString 验证精确 8 字节长度。

Ref: https://github.com/filecoin-project/lotus/pull/13696