### PR TITLE
fix(eth-topics): reject filter topics exceeding 4

### DIFF
--- a/app/submodule/eth/eth_utils.go
+++ b/app/submodule/eth/eth_utils.go
@@ -461,6 +461,9 @@ func newEthTxFromSignedMessage(ctx context.Context, smsg *types.SignedMessage, s
 }
 
 func parseEthTopics(topics types.EthTopicSpec) (map[string][][]byte, error) {
+	if len(topics) > 4 {
+		return nil, fmt.Errorf("invalid filter topic count: expected at most 4 topics, got %d", len(topics))
+	}
 	keys := map[string][][]byte{}
 	for idx, vals := range topics {
 		if len(vals) == 0 {


### PR DESCRIPTION
eth_newFilter 和 eth_getLogs 的 topics 参数支持最多 4 组（origins + 3 nested）。
超出时返回 invalid params 错误，对齐以太坊 JSON-RPC 规范。

Ref: https://github.com/filecoin-project/lotus/pull/13676