### PR TITLE
fix(eth-null-epoch): reject null rounds in block execution APIs

### DIFF
--- a/app/submodule/eth/eth_api.go
+++ b/app/submodule/eth/eth_api.go
@@ -511,7 +511,7 @@ func (a *ethAPI) EthGetBlockReceipts(ctx context.Context, blockParam types.EthBl
 }
 
 func (a *ethAPI) EthGetBlockReceiptsLimited(ctx context.Context, blockParam types.EthBlockNumberOrHash, limit abi.ChainEpoch) ([]*types.EthTxReceipt, error) {
-	ts, err := getTipsetByEthBlockNumberOrHash(ctx, a.em.chainModule.ChainReader, blockParam)
+	ts, err := getTipsetByEthBlockNumberOrHashStrict(ctx, a.em.chainModule.ChainReader, blockParam)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tipset: %w", err)
 	}

--- a/app/submodule/eth/eth_utils.go
+++ b/app/submodule/eth/eth_utils.go
@@ -89,6 +89,28 @@ func getTipsetByBlockNumber(ctx context.Context, store *chain.Store, blkParam st
 	}
 }
 
+// getTipsetByEthBlockNumberOrHashStrict is a strict variant that rejects null rounds.
+// When a block number is explicitly given and the requested epoch has no blocks,
+// it returns ErrNullRound instead of silently returning the next non-null tipset.
+func getTipsetByEthBlockNumberOrHashStrict(ctx context.Context, store *chain.Store, blkParam types.EthBlockNumberOrHash) (*types.TipSet, error) {
+	ts, err := getTipsetByEthBlockNumberOrHash(ctx, store, blkParam)
+	if err != nil {
+		return nil, err
+	}
+
+	// When a block number is explicitly given, verify the returned tipset's
+	// height matches the requested height. If they differ, the requested epoch
+	// was a null round.
+	if blkParam.BlockNumber != nil {
+		requested := abi.ChainEpoch(*blkParam.BlockNumber)
+		if ts.Height() != requested {
+			return nil, ErrNullRound
+		}
+	}
+
+	return ts, nil
+}
+
 func getTipsetByEthBlockNumberOrHash(ctx context.Context, store *chain.Store, blkParam types.EthBlockNumberOrHash) (*types.TipSet, error) {
 	head := store.GetHead()
 


### PR DESCRIPTION
EthGetBlockReceipts 等 block execution API 在遇到 null epoch（空区块间隔）时
应直接返回错误而非对错误高度执行。新增 getTipsetByEthBlockNumberOrHashStrict
验证返回的 tipset 高度与请求高度一致。

Ref: https://github.com/filecoin-project/lotus/pull/13694